### PR TITLE
Time sql

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
@@ -40,6 +40,7 @@ public final class BlockEncodingManager
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
+import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
+import static com.facebook.presto.common.array.Arrays.ensureCapacity;
+import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+
+// 12-byte fixed-width block for high-precision timestamps (p > 6).
+// Each position stores 3 consecutive ints: [high32(epochMicros), low32(epochMicros), picosOfMicro].
+// getLong(position, 0) returns epochMicros; getInt(position) returns picosOfMicro.
+public class Fixed12ArrayBlock
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlock.class).instanceSize();
+    public static final int FIXED12_BYTES = Integer.BYTES * 3;
+    public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
+
+    private static final int INTS_PER_POSITION = 3;
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long retainedSizeInBytes;
+
+    public Fixed12ArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values);
+    }
+
+    Fixed12ArrayBlock(int positionOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - (positionOffset * INTS_PER_POSITION) < positionCount * INTS_PER_POSITION) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    // Returns epochMicros at position; offset must be 0.
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position + positionOffset);
+    }
+
+    // Returns picosOfMicro at position.
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return getPicosOfMicro(position + positionOffset);
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && isNullUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        blockBuilder.writeLong(getEpochMicros(internalPosition))
+                .writeInt(getPicosOfMicro(internalPosition))
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            int internalPosition = position + positionOffset;
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(internalPosition));
+            output.writeInt(getPicosOfMicro(internalPosition));
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                new int[] {
+                        values[internalPosition * INTS_PER_POSITION],
+                        values[internalPosition * INTS_PER_POSITION + 1],
+                        values[internalPosition * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            int internalPosition = position + positionOffset;
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[internalPosition];
+            }
+            newValues[i * INTS_PER_POSITION] = values[internalPosition * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[internalPosition * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[internalPosition * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+        return new Fixed12ArrayBlock(positionOffset + this.positionOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlock(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getPicosOfMicro(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return positionOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public Block appendNull()
+    {
+        boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
+        int[] newValues = ensureCapacity(values, (positionOffset + positionCount + 1) * INTS_PER_POSITION, SMALL, PRESERVE);
+        return new Fixed12ArrayBlock(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Fixed12ArrayBlock other = (Fixed12ArrayBlock) obj;
+        return this.positionOffset == other.positionOffset &&
+                this.positionCount == other.positionCount &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                this.retainedSizeInBytes == other.retainedSizeInBytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset, positionCount, Arrays.hashCode(valueIsNull), Arrays.hashCode(values), retainedSizeInBytes);
+    }
+
+    // Reconstruct epochMicros from two ints at internalPosition.
+    // & 0xFFFFFFFFL prevents sign extension of the low 32-bit word.
+    private long getEpochMicros(int internalPosition)
+    {
+        int base = internalPosition * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private int getPicosOfMicro(int internalPosition)
+    {
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.Fixed12ArrayBlock.FIXED12_BYTES;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+// Builder for Fixed12ArrayBlock.
+//
+// Write protocol — each non-null entry must follow this exact sequence:
+//   writeLong(epochMicros)   — stores the 8-byte epoch-microseconds component
+//   writeInt(picosOfMicro)   — stores the 4-byte sub-microsecond remainder [0, 999_999]
+//   closeEntry()             — commits the position; no heap allocation in the hot path
+//
+// Null entries are written with appendNull() alone — no prior writeLong/writeInt call.
+// Violating either ordering rule throws IllegalStateException immediately.
+public class Fixed12ArrayBlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlockBuilder.class).instanceSize();
+    private static final Block NULL_VALUE_BLOCK = new Fixed12ArrayBlock(0, 1, new boolean[] {true}, new int[3]);
+
+    private static final int INTS_PER_POSITION = 3;
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+
+    private boolean[] valueIsNull = new boolean[0];
+    private int[] values = new int[0];
+
+    private long retainedSizeInBytes;
+
+    // Tracks which part of the current entry has been written: 0 = none, 1 = writeLong done, 2 = writeInt done.
+    private int entryFieldCount;
+
+    public Fixed12ArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        updateDataSize();
+    }
+
+    // Writes epochMicros as two ints (high32, low32). Must be followed by writeInt(picosOfMicro).
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("writeLong must be the first write for each entry");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        int base = positionCount * INTS_PER_POSITION;
+        values[base] = (int) (value >>> 32);
+        values[base + 1] = (int) value;
+        entryFieldCount = 1;
+        hasNonNullValue = true;
+        return this;
+    }
+
+    // Writes picosOfMicro. Must follow writeLong(epochMicros).
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        if (entryFieldCount != 1) {
+            throw new IllegalStateException("writeInt must follow writeLong for each entry");
+        }
+        values[positionCount * INTS_PER_POSITION + 2] = value;
+        entryFieldCount = 2;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (entryFieldCount != 2) {
+            throw new IllegalStateException(
+                    "Each entry requires writeLong(epochMicros) then writeInt(picosOfMicro) before closeEntry()");
+        }
+        positionCount++;
+        entryFieldCount = 0;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        valueIsNull[positionCount] = true;
+        hasNullValue = true;
+        positionCount++;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
+        return new Fixed12ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * INTS_PER_POSITION);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return values[position * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        blockBuilder.writeLong(getEpochMicros(position))
+                .writeInt(values[position * INTS_PER_POSITION + 2])
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(position));
+            output.writeInt(values[position * INTS_PER_POSITION + 2]);
+        }
+    }
+
+    @Override
+    public BlockBuilder readPositionFrom(SliceInput input)
+    {
+        boolean isNull = input.readByte() == 0;
+        if (isNull) {
+            appendNull();
+        }
+        else {
+            writeLong(input.readLong());
+            writeInt(input.readInt());
+            closeEntry();
+        }
+        return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                valueIsNull[position] ? new boolean[] {true} : null,
+                new int[] {
+                        values[position * INTS_PER_POSITION],
+                        values[position * INTS_PER_POSITION + 1],
+                        values[position * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (hasNullValue) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            newValues[i * INTS_PER_POSITION] = values[position * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[position * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[position * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        return new Fixed12ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlockBuilder(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    private long getEpochMicros(int position)
+    {
+        int base = position * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
+import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
+
+// Wire format (per non-null position): 8-byte epochMicros (long) + 4-byte picosOfMicro (int) = 12 bytes.
+public class Fixed12ArrayBlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "FIXED12_ARRAY";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        boolean mayHaveNull = block.mayHaveNull();
+        for (int position = 0; position < positionCount; position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        int[] values = new int[positionCount * 3];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull == null || !valueIsNull[position]) {
+                long epochMicros = sliceInput.readLong();
+                int picosOfMicro = sliceInput.readInt();
+                int base = position * 3;
+                values[base] = (int) (epochMicros >>> 32);
+                values[base + 1] = (int) epochMicros;
+                values[base + 2] = picosOfMicro;
+            }
+        }
+
+        return new Fixed12ArrayBlock(0, positionCount, valueIsNull, values);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -108,7 +108,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
@@ -123,13 +123,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, Long.BYTES);
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(null, positionCount);
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Objects;
+
+// Value type for timestamps with precision > 6. Two fields pack 12 bytes:
+// - epochMicros (8 bytes): microseconds since 1970-01-01T00:00:00 UTC, negative for pre-1970
+// - picosOfMicro (4 bytes): sub-microsecond remainder, always in [0, 999_999]
+public final class LongTimestamp
+{
+    public static final int MAX_PICOS_OF_MICRO = 999_999;
+
+    private final long epochMicros;
+    private final int picosOfMicro;
+
+    public LongTimestamp(long epochMicros, int picosOfMicro)
+    {
+        if (picosOfMicro < 0 || picosOfMicro > MAX_PICOS_OF_MICRO) {
+            throw new IllegalArgumentException(
+                    "picosOfMicro must be in [0, " + MAX_PICOS_OF_MICRO + "]: " + picosOfMicro);
+        }
+        this.epochMicros = epochMicros;
+        this.picosOfMicro = picosOfMicro;
+    }
+
+    public long getEpochMicros()
+    {
+        return epochMicros;
+    }
+
+    public int getPicosOfMicro()
+    {
+        return picosOfMicro;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongTimestamp that = (LongTimestamp) o;
+        return epochMicros == that.epochMicros && picosOfMicro == that.picosOfMicro;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(epochMicros, picosOfMicro);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LongTimestamp{epochMicros=" + epochMicros + ", picosOfMicro=" + picosOfMicro + "}";
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampParametricType.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.TimestampType.DEFAULT_PRECISION;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+
+// Resolves "timestamp(p)" type signatures to TimestampType instances.
+// Registered alongside the bare TIMESTAMP singleton so the type registry can
+// handle both "timestamp" (→ p=3) and "timestamp(p)" (→ any precision in [0,12]).
+public class TimestampParametricType
+        implements ParametricType
+{
+    public static final TimestampParametricType TIMESTAMP = new TimestampParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.TIMESTAMP;
+    }
+
+    @Override
+    public Type createType(List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return createTimestampType(DEFAULT_PRECISION);
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException("TIMESTAMP requires exactly one precision parameter, got: " + parameters.size());
+        }
+        TypeParameter parameter = parameters.get(0);
+        if (!parameter.isLongLiteral()) {
+            throw new IllegalArgumentException("TIMESTAMP precision must be an integer literal");
+        }
+        long precision = parameter.getLongLiteral();
+        return createTimestampType((int) precision);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -14,6 +14,11 @@
 package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
+import com.facebook.presto.common.block.Fixed12ArrayBlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.Objects;
@@ -132,6 +137,42 @@ public final class TimestampType
     public boolean isShort()
     {
         return precision <= MAX_SHORT_PRECISION;
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        if (isShort()) {
+            return super.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+        }
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
+        }
+        return new Fixed12ArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, maxBlockSizeInBytes / Fixed12ArrayBlock.FIXED12_BYTES));
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        if (isShort()) {
+            return super.createBlockBuilder(blockBuilderStatus, expectedEntries);
+        }
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, Fixed12ArrayBlock.FIXED12_BYTES);
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        if (isShort()) {
+            return super.createFixedSizeBlockBuilder(positionCount);
+        }
+        return new Fixed12ArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -17,63 +17,129 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-//
-// TIMESTAMP is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-// TIMESTAMP_MICROSECONDS is stored as microseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
+// Short timestamps (p ≤ 6) are stored as a single epoch-scaled long (e.g. epoch-millis for p=3,
+// epoch-micros for p=6). High-precision timestamps (p > 6) require LongTimestamp, a separate
+// 12-byte fixed-width value type that pairs epochMicros with a picosOfMicro remainder.
 public final class TimestampType
         extends AbstractLongType
 {
-    public static final TimestampType TIMESTAMP = new TimestampType(MILLISECONDS);
-    public static final TimestampType TIMESTAMP_MICROSECONDS = new TimestampType(MICROSECONDS);
+    public static final int MAX_PRECISION = 12;
+    public static final int MAX_SHORT_PRECISION = 6;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private final TimeUnit precision;
+    private static final long[] PRECISION_SCALE = {
+            1L,                     // p=0  (seconds)
+            10L,                    // p=1
+            100L,                   // p=2
+            1_000L,                 // p=3  (milliseconds)
+            10_000L,                // p=4
+            100_000L,               // p=5
+            1_000_000L,             // p=6  (microseconds)
+            10_000_000L,            // p=7
+            100_000_000L,           // p=8
+            1_000_000_000L,         // p=9  (nanoseconds)
+            10_000_000_000L,        // p=10
+            100_000_000_000L,       // p=11
+            1_000_000_000_000L,     // p=12 (picoseconds)
+    };
 
-    private TimestampType(TimeUnit precision)
+    private static final TimestampType[] INSTANCES = new TimestampType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampType(p);
+        }
+    }
+
+    public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
+
+    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
+    // on type-signature base strings continues to work without changes.
+    public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
+
+    private final int precision;
+
+    public static TimestampType createTimestampType(int precision)
     {
-        super(parseTypeSignature(getType(precision)));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
         this.precision = precision;
     }
 
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP);
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            // Preserve "timestamp microseconds" for the same reason.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
+    }
+
+    /**
+     * Returns a {@link SqlTimestamp} for the value at {@code position}.
+     *
+     * <p>Only precision {@value #DEFAULT_PRECISION} (milliseconds) and precision
+     * {@value #MAX_SHORT_PRECISION} (microseconds) are supported. All other precisions
+     * throw {@link UnsupportedOperationException}; callers that receive a {@code TimestampType}
+     * from generic code should check {@link #isShort()} and read high-precision values
+     * directly from the block as {@link LongTimestamp} instead.
+     */
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
-
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + "); read the block as LongTimestamp");
+        }
+        java.util.concurrent.TimeUnit unit = toTimeUnit(precision);
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), precision);
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
         }
-        else {
-            return new SqlTimestamp(block.getLong(position), precision);
-        }
+        return new SqlTimestamp(block.getLong(position), unit);
     }
 
-    public TimeUnit getPrecision()
+    public int getPrecision()
     {
-        return this.precision;
+        return precision;
+    }
+
+    // p ≤ 6 fits in a single long; p > 6 requires the LongTimestamp value type.
+    public boolean isShort()
+    {
+        return precision <= MAX_SHORT_PRECISION;
     }
 
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        if (precision == MICROSECONDS) {
-            return other == TIMESTAMP_MICROSECONDS;
-        }
-        if (precision == MILLISECONDS) {
-            return other == TIMESTAMP;
-        }
-        throw new UnsupportedOperationException("Unsupported precision " + precision);
+        // One interned instance per precision level, so reference equality is sufficient.
+        return this == other;
     }
 
     @Override
@@ -82,38 +148,48 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
-    /**
-     * Gets the timestamp's number of total seconds.
-     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
-     *
-     * Returns:
-     * the total seconds in timestamp
-     */
+    // Floor division handles negative (pre-1970) timestamps correctly; Java % does not.
     public long getEpochSecond(long timestamp)
     {
-        return this.precision.toSeconds(timestamp);
+        return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
-    /**
-     * Gets the timestamp's nanosecond portion.
-     *
-     * Returns:
-     * this timestamp's fractional seconds component
-     */
+    // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
-        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
-        return (int) precision.toNanos(timestamp % unitsPerSecond);
+        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
+        return (int) (fractional * (1_000_000_000L / PRECISION_SCALE[precision]));
     }
 
-    private static String getType(TimeUnit precision)
+    public long toEpochMillis(long timestamp)
     {
-        if (precision == MICROSECONDS) {
-            return StandardTypes.TIMESTAMP_MICROSECONDS;
+        return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
+    }
+
+    public long fromEpochComponents(long epochSecond, int nanos)
+    {
+        if (!isShort()) {
+            // p > 6 timestamps are stored as LongTimestamp (epochMicros + picosOfMicro),
+            // not as a single scaled long; this method cannot produce a valid value for them.
+            throw new UnsupportedOperationException(
+                    "fromEpochComponents requires a short timestamp (p ≤ 6); use LongTimestamp for p > 6");
         }
-        if (precision == MILLISECONDS) {
-            return StandardTypes.TIMESTAMP;
+        // For p ≤ 6, scale ≤ 1_000_000, so 1_000_000_000 / scale is always ≥ 1000 (no zero divisor).
+        long scale = PRECISION_SCALE[precision];
+        return epochSecond * scale + nanos / (1_000_000_000L / scale);
+    }
+
+    private static java.util.concurrent.TimeUnit toTimeUnit(int precision)
+    {
+        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
+        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
+        if (precision == DEFAULT_PRECISION) {
+            return MILLISECONDS;
         }
-        throw new IllegalArgumentException("Unsupported precision " + precision);
+        if (precision == MAX_SHORT_PRECISION) {
+            return MICROSECONDS;
+        }
+        throw new UnsupportedOperationException(
+                "getObjectValue is not implemented for TIMESTAMP(" + precision + "); supported: p=3 (millis), p=6 (micros)");
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -66,8 +66,7 @@ public final class TimestampType
 
     public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
 
-    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
-    // on type-signature base strings continues to work without changes.
+    // Interned instance for microsecond precision. Type signature is now "timestamp(6)".
     public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
 
     private final int precision;
@@ -93,12 +92,7 @@ public final class TimestampType
             // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
             return parseTypeSignature(StandardTypes.TIMESTAMP);
         }
-        if (precision == MAX_SHORT_PRECISION) {
-            // Preserve "timestamp microseconds" for the same reason.
-            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
-        }
-        // Other precisions use a numeric parameter; the type registry does not yet recognize the
-        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        // All other precisions serialize as "timestamp(p)" with a numeric parameter.
         return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneParametricType.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.DEFAULT_PRECISION;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+
+// Resolves "timestamp with time zone(p)" type signatures to TimestampWithTimeZoneType instances.
+public class TimestampWithTimeZoneParametricType
+        implements ParametricType
+{
+    public static final TimestampWithTimeZoneParametricType TIMESTAMP_WITH_TIME_ZONE =
+            new TimestampWithTimeZoneParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
+    }
+
+    @Override
+    public Type createType(List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return createTimestampWithTimeZoneType(DEFAULT_PRECISION);
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException(
+                    "TIMESTAMP WITH TIME ZONE requires exactly one precision parameter, got: " + parameters.size());
+        }
+        TypeParameter parameter = parameters.get(0);
+        if (!parameter.isLongLiteral()) {
+            throw new IllegalArgumentException("TIMESTAMP WITH TIME ZONE precision must be an integer literal");
+        }
+        long precision = parameter.getLongLiteral();
+        return createTimestampWithTimeZoneType((int) precision);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -16,17 +16,60 @@ package com.facebook.presto.common.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
+import java.util.Objects;
+
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
 
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
-    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+    public static final int MAX_PRECISION = 12;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private TimestampWithTimeZoneType()
+    private static final TimestampWithTimeZoneType[] INSTANCES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampWithTimeZoneType(p);
+        }
+    }
+
+    // Preserves "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = INSTANCES[DEFAULT_PRECISION];
+
+    private final int precision;
+
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampWithTimeZoneType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp with time zone(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+    }
+
+    public int getPrecision()
+    {
+        return precision;
     }
 
     /**
@@ -78,12 +121,13 @@ public final class TimestampWithTimeZoneType
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == TIMESTAMP_WITH_TIME_ZONE;
+        // One interned instance per precision level, so reference equality is sufficient.
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return getClass().hashCode();
+        return Objects.hash(getClass(), precision);
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.TimestampType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestFixed12ArrayBlock
+{
+    @Test
+    public void testSinglePositionRoundTrip()
+    {
+        long epochMicros = 1_000_000_000L;
+        int picosOfMicro = 500_000;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 1);
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        // Pre-1970: epochMicros is negative
+        long epochMicros = -1_000_000L;
+        int picosOfMicro = 999_999;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testMultiplePositions()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(200L).writeInt(999_999).closeEntry();
+        builder.writeLong(-300L).writeInt(500_000).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getLong(0, 0), 100L);
+        assertEquals(block.getInt(0), 0);
+        assertEquals(block.getLong(1, 0), 200L);
+        assertEquals(block.getInt(1), 999_999);
+        assertEquals(block.getLong(2, 0), -300L);
+        assertEquals(block.getInt(2), 500_000);
+    }
+
+    @Test
+    public void testNullPosition()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 2);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+    }
+
+    @Test
+    public void testSizeInBytes()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 4);
+        for (int i = 0; i < 4; i++) {
+            builder.writeLong((long) i * 1000).writeInt(i).closeEntry();
+        }
+        Block block = builder.build();
+        // 12 bytes data + 1 byte null flag per position = 13 bytes per position
+        assertEquals(block.getSizeInBytes(), Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * 4L);
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForLongPrecision()
+    {
+        // p > 6 should return Fixed12ArrayBlockBuilder
+        TimestampType longType = createTimestampType(7);
+        assertFalse(longType.isShort());
+        BlockBuilder builder = longType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof Fixed12ArrayBlockBuilder,
+                "Expected Fixed12ArrayBlockBuilder for p=7, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForShortPrecision()
+    {
+        // p <= 6 should return LongArrayBlockBuilder (the default from AbstractLongType)
+        TimestampType shortType = createTimestampType(6);
+        assertTrue(shortType.isShort());
+        BlockBuilder builder = shortType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof LongArrayBlockBuilder,
+                "Expected LongArrayBlockBuilder for p=6, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testExtremeNegativeEpoch()
+    {
+        // Long.MIN_VALUE is a valid epochMicros (no restriction)
+        long epochMicros = Long.MIN_VALUE;
+        int picosOfMicro = 0;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
@@ -47,6 +47,7 @@ public final class TestingBlockEncodingSerde
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestLongTimestamp
+{
+    @Test
+    public void testConstructorStoresFields()
+    {
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 500_000);
+        assertEquals(ts.getEpochMicros(), 1_000_000L);
+        assertEquals(ts.getPicosOfMicro(), 500_000);
+    }
+
+    @Test
+    public void testPicosOfMicroLowerBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test
+    public void testPicosOfMicroUpperBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 999_999);
+        assertEquals(ts.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testPicosOfMicroNegativeThrows()
+    {
+        try {
+            new LongTimestamp(0L, -1);
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testPicosOfMicroTooLargeThrows()
+    {
+        try {
+            new LongTimestamp(0L, 1_000_000);
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        // Pre-1970 timestamp: negative epochMicros is valid
+        LongTimestamp ts = new LongTimestamp(-1_000_000L, 0);
+        assertEquals(ts.getEpochMicros(), -1_000_000L);
+    }
+
+    @Test
+    public void testImmutable()
+    {
+        // LongTimestamp has no setters — verified by reading fields without modification
+        LongTimestamp ts = new LongTimestamp(42L, 100);
+        assertEquals(ts.getEpochMicros(), 42L);
+        assertEquals(ts.getPicosOfMicro(), 100);
+        // No setter methods exist; this is verified at compile time by the absence of set* methods
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampType
+{
+    @Test
+    public void testInterningReturnsSameReference()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertSame(createTimestampType(p), createTimestampType(p),
+                    "createTimestampType(" + p + ") must return same reference on repeated calls");
+        }
+    }
+
+    @Test
+    public void testAllInstancesPreAllocated()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertNotNull(createTimestampType(p), "Instance for precision " + p + " must be pre-allocated");
+        }
+    }
+
+    @Test
+    public void testTimestampConstantBackwardCompatibility()
+    {
+        assertSame(TIMESTAMP, createTimestampType(3), "TIMESTAMP must be same reference as createTimestampType(3)");
+        assertEquals(TIMESTAMP.getPrecision(), 3, "TIMESTAMP.getPrecision() must return 3");
+    }
+
+    @Test
+    public void testGetPrecisionReturnsInt()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertEquals(createTimestampType(p).getPrecision(), p,
+                    "getPrecision() must return " + p + " for createTimestampType(" + p + ")");
+        }
+    }
+
+    @Test
+    public void testIsShortBoundary()
+    {
+        for (int p = 0; p <= 6; p++) {
+            assertTrue(createTimestampType(p).isShort(), "isShort() must return true for p=" + p);
+        }
+        for (int p = 7; p <= 12; p++) {
+            assertFalse(createTimestampType(p).isShort(), "isShort() must return false for p=" + p);
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MIN_VALUE));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testInvalidPrecisionErrorMessage()
+    {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        assertTrue(e.getMessage().contains("-1"), "Error message must contain the invalid value");
+
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        assertTrue(e2.getMessage().contains("13"), "Error message must contain the invalid value");
+    }
+
+    // Additional: TIMESTAMP_MICROSECONDS = createTimestampType(6) with precision 6
+    @Test
+    public void testTimestampMicrosecondsIsInterned()
+    {
+        assertSame(TIMESTAMP_MICROSECONDS, createTimestampType(6),
+                "TIMESTAMP_MICROSECONDS must be same reference as createTimestampType(6)");
+        assertEquals(TIMESTAMP_MICROSECONDS.getPrecision(), 6);
+    }
+
+    // Additional: reference equality serves as type equality (interning guarantee)
+    @Test
+    public void testReferenceEqualityIsTypeEquality()
+    {
+        for (int p1 = 0; p1 <= 12; p1++) {
+            for (int p2 = 0; p2 <= 12; p2++) {
+                if (p1 == p2) {
+                    assertEquals(createTimestampType(p1), createTimestampType(p2));
+                }
+                else {
+                    assertFalse(createTimestampType(p1).equals(createTimestampType(p2)),
+                            "Types with different precision must not be equal");
+                }
+            }
+        }
+    }
+
+    // Additional: getEpochSecond and getNanos correctness for p=3 (millis)
+    @Test
+    public void testEpochComponentsMillis()
+    {
+        TimestampType ts = createTimestampType(3);
+        // 1 second = 1000 ms; epochSecond=1, nanos=0
+        assertEquals(ts.getEpochSecond(1_000L), 1L);
+        assertEquals(ts.getNanos(1_000L), 0);
+        // 1500 ms = 1s + 500ms
+        assertEquals(ts.getEpochSecond(1_500L), 1L);
+        assertEquals(ts.getNanos(1_500L), 500_000_000);
+        // Negative: -1 ms = -1s + 999ms
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_000_000);
+    }
+
+    // Additional: getEpochSecond and getNanos correctness for p=6 (micros)
+    @Test
+    public void testEpochComponentsMicros()
+    {
+        TimestampType ts = createTimestampType(6);
+        // 1 second = 1_000_000 µs
+        assertEquals(ts.getEpochSecond(1_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000L), 0);
+        // 1_500_000 µs = 1s + 500_000µs = 1s + 500ms
+        assertEquals(ts.getEpochSecond(1_500_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000L), 500_000_000);
+        // Negative: -1 µs → epochSecond=-1, nanos=999_999_000
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_000);
+    }
+
+    // Additional: toEpochMillis helper
+    @Test
+    public void testToEpochMillis()
+    {
+        assertEquals(createTimestampType(3).toEpochMillis(1_500L), 1_500L);
+        assertEquals(createTimestampType(6).toEpochMillis(1_500_000L), 1_500L);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampTypeSignature.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampTypeSignature.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestampTypeSignature
+{
+    @Test
+    public void testDefaultPrecisionSerializesWithoutParam()
+    {
+        TimestampType ts3 = createTimestampType(3);
+        assertEquals(ts3.getTypeSignature().toString(), "timestamp");
+        assertEquals(ts3.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testNonDefaultPrecisionsSerializeWithParam()
+    {
+        for (int p = 0; p <= 12; p++) {
+            if (p == 3) {
+                continue;
+            }
+            TimestampType type = createTimestampType(p);
+            String sig = type.getTypeSignature().toString();
+            assertEquals(sig, "timestamp(" + p + ")",
+                    "Expected timestamp(" + p + ") but got: " + sig);
+        }
+    }
+
+    @Test
+    public void testMicrosecondsPrecisionUsesParametricForm()
+    {
+        TimestampType ts6 = createTimestampType(6);
+        assertEquals(ts6.getTypeSignature().toString(), "timestamp(6)");
+        assertEquals(ts6.getTypeSignature().getBase(), "timestamp");
+        assertEquals(ts6.getTypeSignature().getParameters().size(), 1);
+        assertEquals(ts6.getTypeSignature().getParameters().get(0).getLongLiteral(), 6L);
+    }
+
+    @Test
+    public void testBareTimestampParsesToDefaultPrecision()
+    {
+        TypeSignature sig = parseTypeSignature("timestamp");
+        assertEquals(sig.getBase(), "timestamp");
+        assertEquals(sig.getParameters().size(), 0);
+        // TimestampParametricType.createType with no params returns TIMESTAMP(3)
+        Type resolved = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of());
+        assertSame(resolved, createTimestampType(3));
+    }
+
+    @Test
+    public void testExplicitPrecision3RoundTrips()
+    {
+        TypeSignature sig = parseTypeSignature("timestamp(3)");
+        assertEquals(sig.getBase(), "timestamp");
+        assertEquals(sig.getParameters().size(), 1);
+        assertEquals(sig.getParameters().get(0).getLongLiteral(), 3L);
+        TypeParameter param = TypeParameter.of(3L);
+        Type resolved = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of(param));
+        assertSame(resolved, createTimestampType(3));
+    }
+
+    @Test
+    public void testRoundTripForAllPrecisions()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampType original = createTimestampType(p);
+            String serialized = original.getTypeSignature().toString();
+
+            // Parse the serialized form back to a TypeSignature
+            TypeSignature parsed = parseTypeSignature(serialized);
+
+            // Reconstruct via TimestampParametricType
+            Type reconstructed;
+            if (parsed.getParameters().isEmpty()) {
+                reconstructed = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of());
+            }
+            else {
+                long precision = parsed.getParameters().get(0).getLongLiteral();
+                reconstructed = TimestampParametricType.TIMESTAMP.createType(
+                        ImmutableList.of(TypeParameter.of(precision)));
+            }
+
+            assertTrue(reconstructed instanceof TimestampType);
+            assertEquals(((TimestampType) reconstructed).getPrecision(), p,
+                    "Round-trip failed for precision " + p);
+            assertSame(reconstructed, original,
+                    "Round-trip returned different instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testMicrosecondsRoundTrip()
+    {
+        TimestampType ts6 = createTimestampType(6);
+        String serialized = ts6.getTypeSignature().toString();
+        assertEquals(serialized, "timestamp(6)");
+
+        TypeSignature parsed = parseTypeSignature(serialized);
+        TypeParameter param = TypeParameter.of(parsed.getParameters().get(0).getLongLiteral());
+        Type reconstructed = TimestampParametricType.TIMESTAMP.createType(ImmutableList.of(param));
+
+        assertSame(reconstructed, ts6);
+        assertEquals(((TimestampType) reconstructed).getPrecision(), 6);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class TestTimestampWithTimeZoneType
+{
+    @Test
+    public void testInterning()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertSame(createTimestampWithTimeZoneType(p), createTimestampWithTimeZoneType(p),
+                    "Expected same instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testPreAllocation()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampWithTimeZoneType instance = createTimestampWithTimeZoneType(p);
+            assertEquals(instance.getPrecision(), p);
+        }
+    }
+
+    @Test
+    public void testBackwardCompatConstant()
+    {
+        assertSame(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getPrecision(), 3);
+    }
+
+    @Test
+    public void testBackwardCompatTypeSignature()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getBase(), "timestamp with time zone");
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testReferenceEquality()
+    {
+        TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(6);
+        TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(6);
+        assertSame(a, b);
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsWithConstant()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testInvalidPrecisionNegative()
+    {
+        try {
+            createTimestampWithTimeZoneType(-1);
+            fail("Expected IllegalArgumentException for precision -1");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionTooLarge()
+    {
+        try {
+            createTimestampWithTimeZoneType(13);
+            fail("Expected IllegalArgumentException for precision 13");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    // All 13 instances are distinct objects
+    @Test
+    public void testDistinctInstances()
+    {
+        for (int p = 0; p <= 12; p++) {
+            for (int q = p + 1; q <= 12; q++) {
+                TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
+                TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
+                // Different precisions → different instances
+                assert a != b : "Expected distinct instances for p=" + p + " and q=" + q;
+            }
+        }
+    }
+}

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -206,22 +206,88 @@ Values of this type are parsed and rendered in the session time zone.
 An optional precision parameter ``p`` (0–12) specifies the number of fractional
 second digits retained:
 
-* ``TIMESTAMP(0)`` — seconds
-* ``TIMESTAMP(3)`` — milliseconds (the default when no precision is given)
-* ``TIMESTAMP(6)`` — microseconds
-* ``TIMESTAMP(9)`` — nanoseconds
-* ``TIMESTAMP(12)`` — picoseconds
+.. list-table::
+   :widths: 20 30 50
+   :header-rows: 1
+
+   * - Type
+     - Resolution
+     - Notes
+   * - ``TIMESTAMP(0)``
+     - Seconds
+     -
+   * - ``TIMESTAMP(1)``
+     - Deciseconds (0.1 s)
+     -
+   * - ``TIMESTAMP(2)``
+     - Centiseconds (0.01 s)
+     -
+   * - ``TIMESTAMP(3)``
+     - Milliseconds
+     - Default; bare ``TIMESTAMP`` is equivalent
+   * - ``TIMESTAMP(4)``
+     - 0.1 ms
+     -
+   * - ``TIMESTAMP(5)``
+     - 0.01 ms
+     -
+   * - ``TIMESTAMP(6)``
+     - Microseconds
+     -
+   * - ``TIMESTAMP(7)``–``TIMESTAMP(12)``
+     - Sub-microsecond (up to picoseconds)
+     - Stored as microseconds + sub-microsecond remainder
 
 Bare ``TIMESTAMP`` is equivalent to ``TIMESTAMP(3)`` and is retained for backward
-compatibility. Precision values 0–6 are stored as a single scaled integer; precision
-values 7–12 store an additional sub-microsecond remainder, enabling nanosecond and
-picosecond resolution.
+compatibility. Precision values 0–6 are stored as a single scaled integer (epoch
+units scaled by the precision); precision values 7–12 additionally store a
+sub-microsecond remainder, enabling nanosecond and picosecond resolution.
+
+**Coercion and CAST**
+
+Presto applies the following rules when mixing ``TIMESTAMP`` values of different
+precisions:
+
+* **Implicit widening** — a lower-precision value is automatically coerced to a
+  higher-precision type wherever the types must match (e.g. both sides of a
+  ``UNION``, function arguments, column assignments). The sub-unit digits that did
+  not exist in the source are zero-filled.
+
+  ::
+
+      -- UNION widens the TIMESTAMP(3) column to TIMESTAMP(6)
+      SELECT ts3_col FROM t1
+      UNION
+      SELECT ts6_col FROM t2   -- result type is TIMESTAMP(6)
+
+* **Explicit narrowing** — reducing precision requires an explicit ``CAST``.
+  Attempting an implicit narrowing (e.g. inserting a ``TIMESTAMP(6)`` value into
+  a ``TIMESTAMP(3)`` column without a ``CAST``) is a type error.
+
+* **Truncation semantics** — ``CAST`` to a lower precision always *truncates toward
+  negative infinity* (floor), never rounds. This matches the behaviour of integer
+  floor division and is consistent for timestamps before and after the Unix epoch.
+
+  ::
+
+      -- Widening: zero-fills sub-millisecond digits
+      CAST(TIMESTAMP '2001-08-22 03:04:05.321' AS TIMESTAMP(6))
+      -- → 2001-08-22 03:04:05.321000
+
+      -- Narrowing: floor-truncates sub-millisecond digits
+      CAST(TIMESTAMP '2001-08-22 03:04:05.321999' AS TIMESTAMP(3))
+      -- → 2001-08-22 03:04:05.321   (not .322)
+
+      -- Floor semantics apply before the epoch too
+      CAST(TIMESTAMP '1969-12-31 23:59:59.999001' AS TIMESTAMP(3))
+      -- → 1969-12-31 23:59:59.999   (not 2000-01-01 00:00:00.000)
 
 .. note::
 
-    Implicit coercion widens from lower to higher precision (e.g. ``TIMESTAMP(3)``
-    to ``TIMESTAMP(6)``) automatically. Narrowing requires an explicit ``CAST``, which
-    truncates (floor) rather than rounds.
+    The short-precision range (p ≤ 6) supports full ``CAST`` between any two
+    precisions. Casts involving long-precision timestamps (p > 6) are not yet
+    supported and will produce a binding error; use an intermediate cast to
+    ``TIMESTAMP(6)`` as a workaround if needed.
 
 Examples::
 
@@ -237,6 +303,8 @@ Values of this type are rendered using the time zone from the value.
 
 Accepts the same optional precision parameter ``p`` (0–12) as ``TIMESTAMP(p)``.
 Bare ``TIMESTAMP WITH TIME ZONE`` is equivalent to ``TIMESTAMP(3) WITH TIME ZONE``.
+The same implicit widening and explicit narrowing rules described for
+``TIMESTAMP(p)`` apply to ``TIMESTAMP(p) WITH TIME ZONE``.
 
 Examples::
 

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -197,21 +197,51 @@ Values of this type are rendered using the time zone from the value.
 
 Example: ``TIME '01:02:03.456 America/Los_Angeles'``
 
-``TIMESTAMP``
-^^^^^^^^^^^^^
+``TIMESTAMP`` / ``TIMESTAMP(p)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Instant in time that includes the date and time of day without a time zone.
 Values of this type are parsed and rendered in the session time zone.
 
-Example: ``TIMESTAMP '2001-08-22 03:04:05.321'``
+An optional precision parameter ``p`` (0–12) specifies the number of fractional
+second digits retained:
 
-``TIMESTAMP WITH TIME ZONE``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``TIMESTAMP(0)`` — seconds
+* ``TIMESTAMP(3)`` — milliseconds (the default when no precision is given)
+* ``TIMESTAMP(6)`` — microseconds
+* ``TIMESTAMP(9)`` — nanoseconds
+* ``TIMESTAMP(12)`` — picoseconds
+
+Bare ``TIMESTAMP`` is equivalent to ``TIMESTAMP(3)`` and is retained for backward
+compatibility. Precision values 0–6 are stored as a single scaled integer; precision
+values 7–12 store an additional sub-microsecond remainder, enabling nanosecond and
+picosecond resolution.
+
+.. note::
+
+    Implicit coercion widens from lower to higher precision (e.g. ``TIMESTAMP(3)``
+    to ``TIMESTAMP(6)``) automatically. Narrowing requires an explicit ``CAST``, which
+    truncates (floor) rather than rounds.
+
+Examples::
+
+    TIMESTAMP '2001-08-22 03:04:05.321'            -- TIMESTAMP(3), milliseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456'         -- TIMESTAMP(6), microseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456789'      -- TIMESTAMP(9), nanoseconds
+
+``TIMESTAMP WITH TIME ZONE`` / ``TIMESTAMP(p) WITH TIME ZONE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Instant in time that includes the date and time of day with a time zone.
 Values of this type are rendered using the time zone from the value.
 
-Example: ``TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'``
+Accepts the same optional precision parameter ``p`` (0–12) as ``TIMESTAMP(p)``.
+Bare ``TIMESTAMP WITH TIME ZONE`` is equivalent to ``TIMESTAMP(3) WITH TIME ZONE``.
+
+Examples::
+
+    TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'      -- milliseconds
+    TIMESTAMP '2001-08-22 03:04:05.123456 America/Los_Angeles'   -- microseconds
 
 ``INTERVAL YEAR TO MONTH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1747,7 +1747,7 @@ public abstract class IcebergAbstractMetadata
             }
             else if (tableVersion.getVersionExpressionType() instanceof TimestampType) {
                 long timestampValue = (long) tableVersion.getTableVersion();
-                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
+                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).toEpochMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
             else if (tableVersion.getVersionExpressionType() instanceof BigintType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -89,8 +89,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -455,7 +453,7 @@ public class IcebergPageSink
         }
         if (type instanceof TimestampType) {
             long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+            return ((TimestampType) type).getPrecision() == 3 ? timestamp * 1_000L : timestamp;
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -469,14 +467,13 @@ public class IcebergPageSink
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
-            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
-                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            Instant instant = Instant.ofEpochSecond(timestampType.getEpochSecond(timestampValue),
+                    timestampType.getNanos(timestampValue));
             LocalDateTime localDateTime = instant
                     .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
                     .toLocalDateTime();
 
-            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
-                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+            return timestampType.fromEpochComponents(localDateTime.toEpochSecond(ZoneOffset.UTC), localDateTime.getNano());
         }
         return value;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -58,7 +58,6 @@ import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
 public class PartitionTable
@@ -299,7 +298,7 @@ public class PartitionTable
         }
         if (type instanceof Types.TimestampType) {
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
-            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == TimestampType.DEFAULT_PRECISION) {
                 return MICROSECONDS.toMillis((long) value);
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.function.SqlFunctionResult;
 import com.facebook.presto.common.type.DistinctTypeInfo;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.TimestampParametricType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
@@ -660,6 +661,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(KDB_TREE);
         addType(SPHERICAL_GEOGRAPHY);
         addParametricType(TimestampParametricType.TIMESTAMP);
+        addParametricType(TimestampWithTimeZoneParametricType.TIMESTAMP_WITH_TIME_ZONE);
         addParametricType(VarcharParametricType.VARCHAR);
         addParametricType(CharParametricType.CHAR);
         addParametricType(DecimalParametricType.DECIMAL);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -432,6 +432,8 @@ import static com.facebook.presto.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static com.facebook.presto.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.operator.scalar.TimestampPrecisionFunctions.AT_TIMEZONE_TIMESTAMP_TZ;
+import static com.facebook.presto.operator.scalar.TimestampPrecisionFunctions.DATE_TRUNC_TIMESTAMP;
 import static com.facebook.presto.operator.scalar.TryCastFunction.TRY_CAST;
 import static com.facebook.presto.operator.scalar.ZipFunction.ZIP_FUNCTIONS;
 import static com.facebook.presto.operator.scalar.ZipWithFunction.ZIP_WITH_FUNCTION;
@@ -964,6 +966,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(VARCHAR_CONCAT, VARBINARY_CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)
                 .function(TIMESTAMP_TO_TIMESTAMP_CAST)
+                .functions(DATE_TRUNC_TIMESTAMP, AT_TIMEZONE_TIMESTAMP_TZ)
                 .function(castVarcharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(castCharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(DECIMAL_AVERAGE_AGGREGATION)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -512,6 +512,7 @@ import static com.facebook.presto.type.MapParametricType.MAP;
 import static com.facebook.presto.type.Re2JRegexpType.RE2J_REGEXP;
 import static com.facebook.presto.type.RowParametricType.ROW;
 import static com.facebook.presto.type.SfmSketchType.SFM_SKETCH;
+import static com.facebook.presto.type.TimestampPrecisionCasts.TIMESTAMP_TO_TIMESTAMP_CAST;
 import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
 import static com.facebook.presto.type.setdigest.SetDigestType.SET_DIGEST;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -962,6 +963,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(ROW_HASH_CODE, ROW_TO_JSON, JSON_TO_ROW, JSON_STRING_TO_ROW, ROW_DISTINCT_FROM, ROW_EQUAL, ROW_GREATER_THAN, ROW_GREATER_THAN_OR_EQUAL, ROW_LESS_THAN, ROW_LESS_THAN_OR_EQUAL, ROW_NOT_EQUAL, ROW_TO_ROW_CAST, ROW_INDETERMINATE)
                 .functions(VARCHAR_CONCAT, VARBINARY_CONCAT)
                 .function(DECIMAL_TO_DECIMAL_CAST)
+                .function(TIMESTAMP_TO_TIMESTAMP_CAST)
                 .function(castVarcharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(castCharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(DECIMAL_AVERAGE_AGGREGATION)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -522,6 +522,12 @@ import static com.facebook.presto.type.MapParametricType.MAP;
 import static com.facebook.presto.type.Re2JRegexpType.RE2J_REGEXP;
 import static com.facebook.presto.type.RowParametricType.ROW;
 import static com.facebook.presto.type.SfmSketchType.SFM_SKETCH;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_DISTINCT_FROM;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_EQUAL;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_HASH_CODE;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_INDETERMINATE;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_LESS_THAN;
+import static com.facebook.presto.type.TimestampComparisonOperators.TIMESTAMP_XX_HASH_64;
 import static com.facebook.presto.type.TimestampPrecisionCasts.TIMESTAMP_TO_TIMESTAMP_CAST;
 import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
 import static com.facebook.presto.type.setdigest.SetDigestType.SET_DIGEST;
@@ -978,6 +984,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(DATE_ADD_TIMESTAMP, DATE_DIFF_TIMESTAMP,
                         TIMESTAMP_ADD_INTERVAL_DAY, INTERVAL_DAY_ADD_TIMESTAMP, TIMESTAMP_SUBTRACT_INTERVAL_DAY,
                         TIMESTAMP_ADD_INTERVAL_YEAR, INTERVAL_YEAR_ADD_TIMESTAMP, TIMESTAMP_SUBTRACT_INTERVAL_YEAR)
+                .functions(TIMESTAMP_EQUAL, TIMESTAMP_LESS_THAN, TIMESTAMP_HASH_CODE, TIMESTAMP_XX_HASH_64, TIMESTAMP_DISTINCT_FROM, TIMESTAMP_INDETERMINATE)
                 .function(castVarcharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(castCharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(DECIMAL_AVERAGE_AGGREGATION)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.function.SqlFunctionResult;
 import com.facebook.presto.common.type.DistinctTypeInfo;
 import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.TimestampParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
@@ -658,6 +659,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(BING_TILE);
         addType(KDB_TREE);
         addType(SPHERICAL_GEOGRAPHY);
+        addParametricType(TimestampParametricType.TIMESTAMP);
         addParametricType(VarcharParametricType.VARCHAR);
         addParametricType(CharParametricType.CHAR);
         addParametricType(DecimalParametricType.DECIMAL);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -396,6 +396,14 @@ import static com.facebook.presto.operator.scalar.ArrayTransformFunction.ARRAY_T
 import static com.facebook.presto.operator.scalar.CastFromUnknownOperator.CAST_FROM_UNKNOWN;
 import static com.facebook.presto.operator.scalar.ConcatFunction.VARBINARY_CONCAT;
 import static com.facebook.presto.operator.scalar.ConcatFunction.VARCHAR_CONCAT;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.DATE_ADD_TIMESTAMP;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.DATE_DIFF_TIMESTAMP;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.INTERVAL_DAY_ADD_TIMESTAMP;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.INTERVAL_YEAR_ADD_TIMESTAMP;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.TIMESTAMP_ADD_INTERVAL_DAY;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.TIMESTAMP_ADD_INTERVAL_YEAR;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.TIMESTAMP_SUBTRACT_INTERVAL_DAY;
+import static com.facebook.presto.operator.scalar.DateArithmeticPrecisionFunctions.TIMESTAMP_SUBTRACT_INTERVAL_YEAR;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
@@ -967,6 +975,9 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(DECIMAL_TO_DECIMAL_CAST)
                 .function(TIMESTAMP_TO_TIMESTAMP_CAST)
                 .functions(DATE_TRUNC_TIMESTAMP, AT_TIMEZONE_TIMESTAMP_TZ)
+                .functions(DATE_ADD_TIMESTAMP, DATE_DIFF_TIMESTAMP,
+                        TIMESTAMP_ADD_INTERVAL_DAY, INTERVAL_DAY_ADD_TIMESTAMP, TIMESTAMP_SUBTRACT_INTERVAL_DAY,
+                        TIMESTAMP_ADD_INTERVAL_YEAR, INTERVAL_YEAR_ADD_TIMESTAMP, TIMESTAMP_SUBTRACT_INTERVAL_YEAR)
                 .function(castVarcharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(castCharToRe2JRegexp(functionsConfig.getRe2JDfaStatesLimit(), functionsConfig.getRe2JDfaRetries()))
                 .function(DECIMAL_AVERAGE_AGGREGATION)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateArithmeticPrecisionFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateArithmeticPrecisionFunctions.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.metadata.SignatureBuilder;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+
+import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.common.type.StandardTypes.INTERVAL_DAY_TO_SECOND;
+import static com.facebook.presto.common.type.StandardTypes.INTERVAL_YEAR_TO_MONTH;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+
+// Precision-preserving date_add, date_diff, and INTERVAL arithmetic for TIMESTAMP(p), p ≤ 6.
+// Uses withVariadicBound("T", "timestamp") so the return type equals the input precision.
+// Sub-millisecond components are preserved: all supported units are ≥ 1ms, so sub-ms is
+// unchanged by the operation itself and is carried through reconstructTimestamp().
+public final class DateArithmeticPrecisionFunctions
+{
+    private static final DateTimeField MONTH_OF_YEAR_UTC = ISOChronology.getInstanceUTC().monthOfYear();
+
+    public static final SqlScalarFunction DATE_ADD_TIMESTAMP = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .name("date_add")
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("varchar"), parseTypeSignature("bigint"), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .description("add the specified amount of time to the timestamp, preserving declared precision")
+            .deterministic(true)
+            .calledOnNullInput(false)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("addField")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction DATE_DIFF_TIMESTAMP = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .name("date_diff")
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("varchar"), parseTypeSignature("T"), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature("bigint"))
+                    .build())
+            .description("difference of the given timestamps in the given unit, preserving declared precision")
+            .deterministic(true)
+            .calledOnNullInput(false)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("diffField")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_ADD_INTERVAL_DAY = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, ADD)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(ADD)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature(INTERVAL_DAY_TO_SECOND))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("addIntervalDayToSecond")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction INTERVAL_DAY_ADD_TIMESTAMP = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, ADD)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(ADD)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature(INTERVAL_DAY_TO_SECOND), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("intervalDayAddTimestamp")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_SUBTRACT_INTERVAL_DAY = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, SUBTRACT)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(SUBTRACT)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature(INTERVAL_DAY_TO_SECOND))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("subtractIntervalDayToSecond")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_ADD_INTERVAL_YEAR = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, ADD)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(ADD)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature(INTERVAL_YEAR_TO_MONTH))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("addIntervalYearToMonth")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction INTERVAL_YEAR_ADD_TIMESTAMP = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, ADD)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(ADD)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature(INTERVAL_YEAR_TO_MONTH), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("intervalYearAddTimestamp")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_SUBTRACT_INTERVAL_YEAR = SqlScalarFunction.builder(DateArithmeticPrecisionFunctions.class, SUBTRACT)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(SUBTRACT)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature(INTERVAL_YEAR_TO_MONTH))
+                    .returnType(parseTypeSignature("T"))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("subtractIntervalYearToMonth")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    private DateArithmeticPrecisionFunctions() {}
+
+    @UsedByGeneratedCode
+    public static long addField(Slice unit, long value, long timestamp, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        long newEpochMillis = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).add(epochMillis, value);
+        return reconstructTimestamp(type, timestamp, epochMillis, newEpochMillis);
+    }
+
+    @UsedByGeneratedCode
+    public static long diffField(Slice unit, long left, long right, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        return DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit)
+                .getDifferenceAsLong(type.toEpochMillis(right), type.toEpochMillis(left));
+    }
+
+    @UsedByGeneratedCode
+    public static long addIntervalDayToSecond(long timestamp, long intervalMillis, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        return reconstructTimestamp(type, timestamp, epochMillis, epochMillis + intervalMillis);
+    }
+
+    @UsedByGeneratedCode
+    public static long intervalDayAddTimestamp(long intervalMillis, long timestamp, long precision)
+    {
+        return addIntervalDayToSecond(timestamp, intervalMillis, precision);
+    }
+
+    @UsedByGeneratedCode
+    public static long subtractIntervalDayToSecond(long timestamp, long intervalMillis, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        return reconstructTimestamp(type, timestamp, epochMillis, epochMillis - intervalMillis);
+    }
+
+    @UsedByGeneratedCode
+    public static long addIntervalYearToMonth(long timestamp, long months, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        long newEpochMillis = MONTH_OF_YEAR_UTC.add(epochMillis, months);
+        return reconstructTimestamp(type, timestamp, epochMillis, newEpochMillis);
+    }
+
+    @UsedByGeneratedCode
+    public static long intervalYearAddTimestamp(long months, long timestamp, long precision)
+    {
+        return addIntervalYearToMonth(timestamp, months, precision);
+    }
+
+    @UsedByGeneratedCode
+    public static long subtractIntervalYearToMonth(long timestamp, long months, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        long newEpochMillis = MONTH_OF_YEAR_UTC.add(epochMillis, -months);
+        return reconstructTimestamp(type, timestamp, epochMillis, newEpochMillis);
+    }
+
+    // Reconstructs a TIMESTAMP(p) value from a new epoch-millis, carrying forward the
+    // sub-millisecond component of the original timestamp unchanged.
+    private static long reconstructTimestamp(TimestampType type, long originalTimestamp, long origEpochMillis, long newEpochMillis)
+    {
+        long origSec = floorDiv(origEpochMillis, 1000L);
+        int origNanos = (int) (floorMod(origEpochMillis, 1000L) * 1_000_000L);
+        long subMillisNative = originalTimestamp - type.fromEpochComponents(origSec, origNanos);
+        long newSec = floorDiv(newEpochMillis, 1000L);
+        int newNanos = (int) (floorMod(newEpochMillis, 1000L) * 1_000_000L);
+        return type.fromEpochComponents(newSec, newNanos) + subMillisNative;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -622,7 +622,7 @@ public final class DateTimeFunctions
         throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid Time field");
     }
 
-    private static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)
+    static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)
     {
         String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
         switch (unitString) {

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TimestampPrecisionFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TimestampPrecisionFunctions.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.NotSupportedException;
+import com.facebook.presto.common.type.TimeZoneNotSupportedException;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.metadata.SignatureBuilder;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Signature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.joda.time.chrono.ISOChronology;
+
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+
+// Precision-preserving date_trunc and at_timezone for TIMESTAMP(p) and TIMESTAMP(p) WITH TIME ZONE.
+// Uses withVariadicBound("T", ...) so the return type equals the input precision, rather than
+// downgrading to the fixed TIMESTAMP(3) returned by the annotation-based overloads.
+// Scoped to short precisions (p ≤ 6); p > 6 will fail at function binding time.
+public final class TimestampPrecisionFunctions
+{
+    private static final Signature DATE_TRUNC_TIMESTAMP_SIGNATURE = SignatureBuilder.builder()
+            .kind(SCALAR)
+            .name("date_trunc")
+            .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+            .argumentTypes(parseTypeSignature("varchar"), parseTypeSignature("T"))
+            .returnType(parseTypeSignature("T"))
+            .build();
+
+    public static final SqlScalarFunction DATE_TRUNC_TIMESTAMP = SqlScalarFunction.builder(TimestampPrecisionFunctions.class)
+            .signature(DATE_TRUNC_TIMESTAMP_SIGNATURE)
+            .description("truncate to the specified precision in UTC")
+            .deterministic(true)
+            .calledOnNullInput(false)
+            .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("truncateTimestamp")
+                            .withExtraParameters(context -> {
+                                TimestampType type = (TimestampType) context.getType("T");
+                                return ImmutableList.of((long) type.getPrecision());
+                            })))
+            .build();
+
+    private static final Signature AT_TIMEZONE_TIMESTAMP_TZ_SIGNATURE = SignatureBuilder.builder()
+            .kind(SCALAR)
+            .name("at_timezone")
+            .typeVariableConstraints(withVariadicBound("T", TIMESTAMP_WITH_TIME_ZONE))
+            .argumentTypes(parseTypeSignature("T"), parseTypeSignature("varchar"))
+            .returnType(parseTypeSignature("T"))
+            .build();
+
+    public static final SqlScalarFunction AT_TIMEZONE_TIMESTAMP_TZ = SqlScalarFunction.builder(TimestampPrecisionFunctions.class)
+            .signature(AT_TIMEZONE_TIMESTAMP_TZ_SIGNATURE)
+            .description("convert timestamp to the given time zone, preserving declared precision")
+            .deterministic(true)
+            .calledOnNullInput(false)
+            .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("atTimezone")))
+            .build();
+
+    private TimestampPrecisionFunctions() {}
+
+    @UsedByGeneratedCode
+    public static long truncateTimestamp(Slice unit, long timestamp, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        long epochMillis = type.toEpochMillis(timestamp);
+        long truncatedMillis = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).roundFloor(epochMillis);
+        long epochSecond = floorDiv(truncatedMillis, 1000L);
+        int nanosFromMillis = (int) (floorMod(truncatedMillis, 1000L) * 1_000_000L);
+        return type.fromEpochComponents(epochSecond, nanosFromMillis);
+    }
+
+    @UsedByGeneratedCode
+    public static long atTimezone(long timestampWithTimeZone, Slice zoneId)
+    {
+        try {
+            return packDateTimeWithZone(unpackMillisUtc(timestampWithTimeZone), zoneId.toStringUtf8());
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1448,8 +1448,13 @@ public class ExpressionAnalyzer
             try {
                 type = functionAndTypeResolver.getType(parseTypeSignature(node.getType()));
             }
-            catch (IllegalArgumentException | UnknownTypeException e) {
+            catch (UnknownTypeException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Unknown type: " + node.getType());
+            }
+            catch (IllegalArgumentException e) {
+                // Propagate the original message so precision-out-of-range errors are user-readable
+                // e.g. "TIMESTAMP precision must be in range [0, 12]: 13"
+                throw new SemanticException(TYPE_MISMATCH, node, e.getMessage());
             }
 
             if (type.equals(UNKNOWN)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -63,7 +63,6 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.SqlToRowExpressionTranslator.translate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.Integer.min;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
@@ -372,7 +371,7 @@ public class ExpressionEquivalence
         @Override
         public int compare(List<T> left, List<T> right)
         {
-            int compareLength = min(left.size(), right.size());
+            int compareLength = Integer.min(left.size(), right.size());
             for (int i = 0; i < compareLength; i++) {
                 int result = elementComparator.compare(left.get(i), right.get(i));
                 if (result != 0) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -573,7 +573,7 @@ public class IOPlanPrinter
             }
             if (type instanceof TimestampType) {
                 TimestampType timestampType = (TimestampType) type;
-                long timestampValue = timestampType.getPrecision().toMillis((Long) value);
+                long timestampValue = timestampType.toEpochMillis((Long) value);
                 return printTimestampWithoutTimeZone(timestampValue);
             }
             if (type instanceof TimestampWithTimeZoneType) {

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TimestampComparisonOperators.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TimestampComparisonOperators.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractLongType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.metadata.SignatureBuilder;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.XxHash64;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.BLOCK_AND_POSITION;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.USE_NULL_FLAG;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static java.util.Arrays.asList;
+
+// Comparison operators for TIMESTAMP(p) where p ≠ 3.
+// Each operator has two choices:
+//   1. RETURN_NULL_ON_NULL (or USE_NULL_FLAG for distinct/indeterminate): used by the expression
+//      interpreter for computed values and short timestamps (p ≤ 6 stored as scaled long).
+//   2. BLOCK_AND_POSITION: used in vectorized block processing and handles all precisions including
+//      p > 6 (Fixed12ArrayBlock with epochMicros + picosOfMicro).
+// Exact-type annotation-based operators in TimestampOperators.java win for p=3 inputs.
+public final class TimestampComparisonOperators
+{
+    private TimestampComparisonOperators() {}
+
+    // TimestampType.getJavaType() returns long.class for all precisions (inherited from AbstractLongType).
+    private static final Optional<Class<?>> LONG_TYPE = Optional.of(long.class);
+
+    public static final SqlScalarFunction TIMESTAMP_EQUAL = SqlScalarFunction.builder(TimestampComparisonOperators.class, EQUAL)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(EQUAL)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BOOLEAN))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .nullableResult(true)
+                    .implementation(mg -> mg
+                            .methods("equalShort")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .nullableResult(true)
+                    .argumentProperties(
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION),
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("equal", asList(LONG_TYPE, LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_LESS_THAN = SqlScalarFunction.builder(TimestampComparisonOperators.class, LESS_THAN)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(LESS_THAN)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BOOLEAN))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("lessThanShort")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .argumentProperties(
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION),
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("lessThan", asList(LONG_TYPE, LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_HASH_CODE = SqlScalarFunction.builder(TimestampComparisonOperators.class, HASH_CODE)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(HASH_CODE)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BIGINT))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("hashCodeShort")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .argumentProperties(valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("hashCodeOperator", asList(LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_XX_HASH_64 = SqlScalarFunction.builder(TimestampComparisonOperators.class, XX_HASH_64)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(XX_HASH_64)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BIGINT))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(mg -> mg
+                            .methods("xxHash64Short")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .argumentProperties(valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("xxHash64", asList(LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_DISTINCT_FROM = SqlScalarFunction.builder(TimestampComparisonOperators.class, IS_DISTINCT_FROM)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(IS_DISTINCT_FROM)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"), parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BOOLEAN))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .argumentProperties(
+                            valueTypeArgumentProperty(USE_NULL_FLAG),
+                            valueTypeArgumentProperty(USE_NULL_FLAG))
+                    .implementation(mg -> mg
+                            .methods("isDistinctFromShort")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .argumentProperties(
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION),
+                            valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("isDistinctFrom", asList(LONG_TYPE, LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_INDETERMINATE = SqlScalarFunction.builder(TimestampComparisonOperators.class, INDETERMINATE)
+            .signature(SignatureBuilder.builder()
+                    .kind(SCALAR)
+                    .operatorType(INDETERMINATE)
+                    .typeVariableConstraints(withVariadicBound("T", TIMESTAMP))
+                    .argumentTypes(parseTypeSignature("T"))
+                    .returnType(parseTypeSignature(BOOLEAN))
+                    .build())
+            .deterministic(true)
+            .choice(choice -> choice
+                    .argumentProperties(valueTypeArgumentProperty(USE_NULL_FLAG))
+                    .implementation(mg -> mg
+                            .methods("indeterminateShort")
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .choice(choice -> choice
+                    .argumentProperties(valueTypeArgumentProperty(BLOCK_AND_POSITION))
+                    .implementation(mg -> mg
+                            .methodWithExplicitJavaTypes("indeterminate", asList(LONG_TYPE))
+                            .withExtraParameters(ctx -> ImmutableList.of((long) ((TimestampType) ctx.getType("T")).getPrecision()))))
+            .build();
+
+    // --- Short-path methods (RETURN_NULL_ON_NULL / USE_NULL_FLAG convention) ---
+    // Used by the expression interpreter for computed values and p ≤ 6 timestamps.
+
+    @UsedByGeneratedCode
+    public static Boolean equalShort(long left, long right, long precision)
+    {
+        return left == right;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean lessThanShort(long left, long right, long precision)
+    {
+        return left < right;
+    }
+
+    @UsedByGeneratedCode
+    public static long hashCodeShort(long value, long precision)
+    {
+        return AbstractLongType.hash(value);
+    }
+
+    @UsedByGeneratedCode
+    public static long xxHash64Short(long value, long precision)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean isDistinctFromShort(long left, boolean leftIsNull, long right, boolean rightIsNull, long precision)
+    {
+        if (leftIsNull != rightIsNull) {
+            return true;
+        }
+        if (leftIsNull) {
+            return false;
+        }
+        return left != right;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean indeterminateShort(long value, boolean isNull, long precision)
+    {
+        return isNull;
+    }
+
+    // --- Block-position methods (BLOCK_AND_POSITION convention) ---
+    // Used in vectorized block processing; handles all precisions including p > 6.
+
+    @UsedByGeneratedCode
+    public static Boolean equal(Block left, int lp, Block right, int rp, long precision)
+    {
+        if (left.isNull(lp) || right.isNull(rp)) {
+            return null;
+        }
+        return compare(left, lp, right, rp, createTimestampType((int) precision)) == 0;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean lessThan(Block left, int lp, Block right, int rp, long precision)
+    {
+        return compare(left, lp, right, rp, createTimestampType((int) precision)) < 0;
+    }
+
+    @UsedByGeneratedCode
+    public static long hashCodeOperator(Block block, int pos, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        if (type.isShort()) {
+            return AbstractLongType.hash(type.getLong(block, pos));
+        }
+        long epochMicros = block.getLong(pos, 0);
+        int picosOfMicro = block.getInt(pos);
+        return AbstractLongType.hash(epochMicros) + 31L * AbstractLongType.hash(picosOfMicro);
+    }
+
+    @UsedByGeneratedCode
+    public static long xxHash64(Block block, int pos, long precision)
+    {
+        TimestampType type = createTimestampType((int) precision);
+        if (type.isShort()) {
+            return XxHash64.hash(type.getLong(block, pos));
+        }
+        long epochMicros = block.getLong(pos, 0);
+        int picosOfMicro = block.getInt(pos);
+        return XxHash64.hash(epochMicros) + 31L * XxHash64.hash(picosOfMicro);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean isDistinctFrom(Block left, int lp, Block right, int rp, long precision)
+    {
+        if (left.isNull(lp) != right.isNull(rp)) {
+            return true;
+        }
+        if (left.isNull(lp)) {
+            return false;
+        }
+        return compare(left, lp, right, rp, createTimestampType((int) precision)) != 0;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean indeterminate(Block block, int pos, long precision)
+    {
+        return block.isNull(pos);
+    }
+
+    // For p ≤ 6 (short): reads the epoch-scaled long via type.getLong.
+    // For p > 6 (long): reads epochMicros via getLong(pos, 0) and picosOfMicro via getInt(pos)
+    // from the Fixed12ArrayBlock, comparing epochMicros first, picosOfMicro as tiebreaker.
+    private static int compare(Block left, int lp, Block right, int rp, TimestampType type)
+    {
+        if (type.isShort()) {
+            return Long.compare(type.getLong(left, lp), type.getLong(right, rp));
+        }
+        long lEpochMicros = left.getLong(lp, 0);
+        int lPicos = left.getInt(lp);
+        long rEpochMicros = right.getLong(rp, 0);
+        int rPicos = right.getInt(rp);
+        int c = Long.compare(lEpochMicros, rEpochMicros);
+        return c != 0 ? c : Integer.compare(lPicos, rPicos);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TimestampPrecisionCasts.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TimestampPrecisionCasts.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.metadata.SignatureBuilder;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.function.Signature;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static java.lang.Math.floorDiv;
+
+// Implements CAST between TIMESTAMP(p1) and TIMESTAMP(p2) for short precisions (p ≤ 6).
+// Widening zero-fills; narrowing truncates toward negative infinity (floor semantics).
+public final class TimestampPrecisionCasts
+{
+    // Units per second for each short precision level (p=0 through p=6).
+    // PRECISION_SCALE[p] = 10^p.
+    static final long[] PRECISION_SCALE = {
+            1L,           // p=0 (seconds)
+            10L,          // p=1
+            100L,         // p=2
+            1_000L,       // p=3 (milliseconds)
+            10_000L,      // p=4
+            100_000L,     // p=5
+            1_000_000L,   // p=6 (microseconds)
+    };
+
+    public static final Signature SIGNATURE = SignatureBuilder.builder()
+            .kind(SCALAR)
+            .operatorType(CAST)
+            .typeVariableConstraints(withVariadicBound("F", TIMESTAMP), withVariadicBound("T", TIMESTAMP))
+            .argumentTypes(parseTypeSignature("F"))
+            .returnType(parseTypeSignature("T"))
+            .build();
+
+    public static final SqlScalarFunction TIMESTAMP_TO_TIMESTAMP_CAST = SqlScalarFunction.builder(TimestampPrecisionCasts.class, CAST)
+            .signature(SIGNATURE)
+            .deterministic(true)
+            .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("shortToShortCast")
+                            .withExtraParameters(context -> {
+                                TimestampType fromType = (TimestampType) context.getType("F");
+                                TimestampType toType = (TimestampType) context.getType("T");
+                                return ImmutableList.of((long) fromType.getPrecision(), (long) toType.getPrecision());
+                            })))
+            .build();
+
+    private TimestampPrecisionCasts() {}
+
+    @UsedByGeneratedCode
+    public static long shortToShortCast(long value, long fromPrecision, long toPrecision)
+    {
+        if (toPrecision == fromPrecision) {
+            return value;
+        }
+        if (toPrecision > fromPrecision) {
+            return value * (PRECISION_SCALE[(int) toPrecision] / PRECISION_SCALE[(int) fromPrecision]);
+        }
+        return floorDiv(value, PRECISION_SCALE[(int) fromPrecision] / PRECISION_SCALE[(int) toPrecision]);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TypeCoercer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TypeCoercer.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -45,6 +46,7 @@ import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
@@ -386,6 +388,12 @@ public class TypeCoercer
             }
             if (fromTypeBaseName.equals(StandardTypes.CHAR) && !functionsConfig.isLegacyCharToVarcharCoercion()) {
                 Type commonSuperType = getCommonSuperTypeForChar((CharType) standardFromType, (CharType) standardToType);
+                return TypeCompatibility.compatible(toSemanticType(toType, commonSuperType), commonSuperType.equals(standardToType));
+            }
+            if (fromTypeBaseName.equals(StandardTypes.TIMESTAMP)) {
+                TimestampType fromTs = (TimestampType) standardFromType;
+                TimestampType toTs = (TimestampType) standardToType;
+                Type commonSuperType = createTimestampType(Math.max(fromTs.getPrecision(), toTs.getPrecision()));
                 return TypeCompatibility.compatible(toSemanticType(toType, commonSuperType), commonSuperType.equals(standardToType));
             }
             if (fromTypeBaseName.equals(StandardTypes.ROW)) {

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateArithmeticPrecisionFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateArithmeticPrecisionFunctions.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestDateArithmeticPrecisionFunctions
+        extends AbstractTestFunctions
+{
+    public TestDateArithmeticPrecisionFunctions()
+    {
+        super(testSessionBuilder()
+                .setSystemProperty("legacy_timestamp", "false")
+                .build());
+    }
+
+    // --- date_add: precision preservation ---
+
+    @Test
+    public void testDateAddHourPreservesP6()
+    {
+        long expectedMicros = new DateTime(2024, 1, 1, 2, 30, 0, 321, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "date_add('hour', 1, CAST(TIMESTAMP '2024-01-01 01:30:00.321' AS TIMESTAMP(6)))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testDateAddP3Unchanged()
+    {
+        // Existing annotation-based overload still wins for p=3 input (regression check)
+        assertFunction(
+                "date_add('hour', 1, TIMESTAMP '2024-01-01 01:30:00.321')",
+                TIMESTAMP,
+                sqlTimestampOf(2024, 1, 1, 2, 30, 0, 321, session));
+    }
+
+    @Test
+    public void testDateAddSubMillisPreserved()
+    {
+        // Sub-millisecond component must survive adding 1 day (all units are ≥ 1ms)
+        long epochMillis = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
+        long epochMicros = epochMillis * 1000L + 456L; // 2024-01-01 00:00:00.000456 UTC
+        long oneDayMillis = 86_400_000L;
+
+        long result = DateArithmeticPrecisionFunctions.addIntervalDayToSecond(epochMicros, oneDayMillis, 6);
+
+        long expectedMicros = (epochMillis + oneDayMillis) * 1000L + 456L;
+        assertEquals(result, expectedMicros);
+    }
+
+    // --- date_diff: precision preservation ---
+
+    @Test
+    public void testDateDiffP6()
+    {
+        assertFunction(
+                "date_diff('second',"
+                        + " CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6)),"
+                        + " CAST(TIMESTAMP '2024-01-01 01:00:00.000' AS TIMESTAMP(6)))",
+                BIGINT,
+                3600L);
+    }
+
+    @Test
+    public void testDateDiffMixedPrecision()
+    {
+        // TIMESTAMP(3) arg is widened to TIMESTAMP(6) via implicit coercion (Story 2.2)
+        assertFunction(
+                "date_diff('second',"
+                        + " TIMESTAMP '2024-01-01 00:00:00.000',"
+                        + " CAST(TIMESTAMP '2024-01-01 01:00:00.000' AS TIMESTAMP(6)))",
+                BIGINT,
+                3600L);
+    }
+
+    // --- INTERVAL arithmetic: precision preservation ---
+
+    @Test
+    public void testTimestampPlusIntervalDayPreservesP6()
+    {
+        long expectedMicros = new DateTime(2024, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6)) + INTERVAL '1' DAY",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testIntervalDayPlusTimestampPreservesP6()
+    {
+        // Commutative form: INTERVAL + TIMESTAMP
+        long expectedMicros = new DateTime(2024, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "INTERVAL '1' DAY + CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testTimestampMinusIntervalDayPreservesP6()
+    {
+        long expectedMicros = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "CAST(TIMESTAMP '2024-01-02 00:00:00.000' AS TIMESTAMP(6)) - INTERVAL '1' DAY",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testTimestampPlusIntervalYearPreservesP6()
+    {
+        long expectedMicros = new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6)) + INTERVAL '1' YEAR",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestTimestampPrecisionFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestTimestampPrecisionFunctions.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
+import com.facebook.presto.common.type.TimeZoneKey;
+import io.airlift.slice.Slices;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.common.type.DateTimeEncoding.unpackZoneKey;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKey;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestTimestampPrecisionFunctions
+        extends AbstractTestFunctions
+{
+    public TestTimestampPrecisionFunctions()
+    {
+        super(testSessionBuilder()
+                .setSystemProperty("legacy_timestamp", "false")
+                .build());
+    }
+
+    // --- date_trunc: precision preservation ---
+
+    @Test
+    public void testDateTruncHourPreservesP6()
+    {
+        // TIMESTAMP(6) input must produce TIMESTAMP(6) output, not TIMESTAMP(3)
+        long expectedMicros = new DateTime(2024, 1, 1, 1, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "date_trunc('hour', CAST(TIMESTAMP '2024-01-01 01:30:45.321' AS TIMESTAMP(6)))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testDateTruncMinutePreservesP6()
+    {
+        long expectedMicros = new DateTime(2024, 1, 1, 1, 30, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "date_trunc('minute', CAST(TIMESTAMP '2024-01-01 01:30:45.321' AS TIMESTAMP(6)))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testDateTruncSecondPreservesP6()
+    {
+        // Sub-second digits are zeroed; type stays TIMESTAMP(6)
+        long expectedMicros = new DateTime(2024, 1, 1, 1, 30, 45, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "date_trunc('second', CAST(TIMESTAMP '2024-01-01 01:30:45.321' AS TIMESTAMP(6)))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testDateTruncNegativeEpochP6()
+    {
+        // floorDiv required for pre-1970 timestamps: 1969-12-31 23:59:59.999 truncated to day
+        long expectedMicros = new DateTime(1969, 12, 31, 0, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000L;
+        assertFunction(
+                "date_trunc('day', CAST(TIMESTAMP '1969-12-31 23:59:59.999' AS TIMESTAMP(6)))",
+                TIMESTAMP_MICROSECONDS,
+                new SqlTimestamp(expectedMicros, TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testDateTruncP3Unchanged()
+    {
+        // Existing p=3 behavior is not affected: exact-type annotation overload still wins
+        assertFunction(
+                "date_trunc('minute', TIMESTAMP '2024-01-01 01:30:45.321')",
+                TIMESTAMP,
+                sqlTimestampOf(2024, 1, 1, 1, 30, 0, 0, session));
+    }
+
+    // --- at_timezone: precision preservation ---
+
+    @Test
+    public void testAtTimezoneP3Unchanged()
+    {
+        // Existing p=3 TIMESTAMP_WITH_TIME_ZONE: exact-type annotation overload still wins (regression)
+        long millis = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
+        TimeZoneKey nyKey = getTimeZoneKey("America/New_York");
+        assertFunction(
+                "at_timezone(from_unixtime(0, 'UTC'), 'America/New_York')",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(millis, nyKey));
+    }
+
+    @Test
+    public void testAtTimezoneImplPreservesMillisAndChangesZone()
+    {
+        // Direct unit test of the implementation: millis are preserved, only zone changes
+        long millis = new DateTime(2024, 6, 15, 12, 0, 0, 0, DateTimeZone.UTC).getMillis();
+        long packed = packDateTimeWithZone(millis, UTC_KEY);
+
+        long result = TimestampPrecisionFunctions.atTimezone(packed, Slices.utf8Slice("America/New_York"));
+
+        TimeZoneKey nyKey = getTimeZoneKey("America/New_York");
+        assertEquals(unpackMillisUtc(result), millis);
+        assertEquals(unpackZoneKey(result), nyKey);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestBuiltInTypeRegistry.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestBuiltInTypeRegistry.java
@@ -210,6 +210,13 @@ public class TestBuiltInTypeRegistry
         assertThat("row(a row(c integer),b varchar(2))", "row(row(c integer),varchar(5))").hasCommonSuperType("row(row(c integer),varchar(5))").canCoerceFirstToSecondOnly();
         assertThat("row(a row(c integer),b varchar(2))", "row(a row(c integer),d varchar(5))").hasCommonSuperType("row(a row(c integer),varchar(5))").canCoerceFirstToSecondOnly();
         assertThat("row(a row(c integer),b varchar(5))", "row(d row(e integer),b varchar(5))").hasCommonSuperType("row(row(integer),b varchar(5))").canCoerceToEachOther();
+
+        assertThat("timestamp", "timestamp(6)").hasCommonSuperType("timestamp(6)").canCoerceFirstToSecondOnly();
+        assertThat("timestamp(6)", "timestamp").hasCommonSuperType("timestamp(6)").canCoerceSecondToFirstOnly();
+        assertThat("timestamp(3)", "timestamp(3)").hasCommonSuperType("timestamp(3)").canCoerceToEachOther();
+        assertThat("timestamp(3)", "timestamp(6)").hasCommonSuperType("timestamp(6)").canCoerceFirstToSecondOnly();
+        assertThat("timestamp(6)", "timestamp(3)").hasCommonSuperType("timestamp(6)").canCoerceSecondToFirstOnly();
+        assertThat("timestamp(0)", "timestamp(6)").hasCommonSuperType("timestamp(6)").canCoerceFirstToSecondOnly();
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampComparisonOperators.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampComparisonOperators.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestampComparisonOperators
+        extends AbstractTestFunctions
+{
+    public TestTimestampComparisonOperators()
+    {
+        super(testSessionBuilder()
+                .setSystemProperty("legacy_timestamp", "false")
+                .build());
+    }
+
+    // Build a Fixed12 block holding one non-null TIMESTAMP(9) value.
+    private static Block longBlock(long epochMicros, int picosOfMicro)
+    {
+        BlockBuilder bb = createTimestampType(9).createBlockBuilder(null, 1);
+        bb.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+        return bb.build();
+    }
+
+    private static Block nullLongBlock()
+    {
+        BlockBuilder bb = createTimestampType(9).createBlockBuilder(null, 1);
+        bb.appendNull();
+        return bb.build();
+    }
+
+    // --- EQUAL p=6 (SQL level) ---
+
+    @Test
+    public void testEqualP6EqualValues()
+    {
+        assertFunction(
+                "CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6)) = CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6))",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testEqualP6DifferentValues()
+    {
+        assertFunction(
+                "CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6)) = CAST(TIMESTAMP '2024-01-01 00:00:00.001' AS TIMESTAMP(6))",
+                BOOLEAN,
+                false);
+    }
+
+    // --- EQUAL p=9 (direct method call — SQL literals max out at p=6) ---
+
+    @Test
+    public void testEqualP9PicosDiffer()
+    {
+        long epochMicros = 1_000_000L;
+        assertEquals(
+                TimestampComparisonOperators.equal(longBlock(epochMicros, 500), 0, longBlock(epochMicros, 501), 0, 9L),
+                Boolean.FALSE);
+    }
+
+    @Test
+    public void testEqualP9SameValue()
+    {
+        long epochMicros = 1_000_000L;
+        assertEquals(
+                TimestampComparisonOperators.equal(longBlock(epochMicros, 500), 0, longBlock(epochMicros, 500), 0, 9L),
+                Boolean.TRUE);
+    }
+
+    @Test
+    public void testEqualNullReturnsNull()
+    {
+        assertNull(TimestampComparisonOperators.equal(nullLongBlock(), 0, longBlock(1_000_000L, 0), 0, 9L));
+    }
+
+    // --- LESS_THAN p=9 ---
+
+    @Test
+    public void testLessThanP9SameMicrosPicosTiebreaker()
+    {
+        long epochMicros = 1_000_000L;
+        assertTrue(TimestampComparisonOperators.lessThan(longBlock(epochMicros, 0), 0, longBlock(epochMicros, 1), 0, 9L));
+        assertFalse(TimestampComparisonOperators.lessThan(longBlock(epochMicros, 1), 0, longBlock(epochMicros, 0), 0, 9L));
+    }
+
+    // --- IS DISTINCT FROM ---
+
+    @Test
+    public void testDistinctFromNullVsNonNull()
+    {
+        assertFunction(
+                "NULL IS DISTINCT FROM CAST(TIMESTAMP '2024-01-01 00:00:00.000' AS TIMESTAMP(6))",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testDistinctFromNullVsNull()
+    {
+        assertFunction(
+                "CAST(NULL AS TIMESTAMP(6)) IS DISTINCT FROM CAST(NULL AS TIMESTAMP(6))",
+                BOOLEAN,
+                false);
+    }
+
+    @Test
+    public void testDistinctFromP9NullVsNonNull()
+    {
+        assertTrue(TimestampComparisonOperators.isDistinctFrom(nullLongBlock(), 0, longBlock(1_000_000L, 0), 0, 9L));
+    }
+
+    @Test
+    public void testDistinctFromP9NullVsNull()
+    {
+        assertFalse(TimestampComparisonOperators.isDistinctFrom(nullLongBlock(), 0, nullLongBlock(), 0, 9L));
+    }
+
+    // --- HASH_CODE p=9 ---
+
+    @Test
+    public void testHashCodeP9ConsistentWithEquality()
+    {
+        long epochMicros = 1_000_000L;
+        Block b1 = longBlock(epochMicros, 500);
+        Block b2 = longBlock(epochMicros, 500);
+        assertEquals(
+                TimestampComparisonOperators.hashCodeOperator(b1, 0, 9L),
+                TimestampComparisonOperators.hashCodeOperator(b2, 0, 9L));
+    }
+
+    // --- p=3 regression: annotation-based operator in TimestampOperators still wins ---
+
+    @Test
+    public void testEqualP3RegressionExistingOverloadWins()
+    {
+        assertFunction(
+                "TIMESTAMP '2024-01-01 00:00:00.000' = TIMESTAMP '2024-01-01 00:00:00.000'",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "TIMESTAMP '2024-01-01 00:00:00.000' = TIMESTAMP '2024-01-01 00:00:00.001'",
+                BOOLEAN,
+                false);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampPrecisionCasts.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampPrecisionCasts.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestTimestampPrecisionCasts
+        extends AbstractTestFunctions
+{
+    public TestTimestampPrecisionCasts()
+    {
+        super(testSessionBuilder()
+                .setSystemProperty("legacy_timestamp", "false")
+                .build());
+    }
+
+    @Test
+    public void testWideningCast()
+    {
+        // CAST(TIMESTAMP(3) AS TIMESTAMP(6)) zero-fills sub-millisecond digits
+        SqlTimestamp ts3 = sqlTimestampOf(2001, 8, 22, 3, 4, 5, 321, session);
+        long micros = ts3.getMicros();
+        assertFunction(
+                "CAST(TIMESTAMP '2001-08-22 03:04:05.321' AS TIMESTAMP(6))",
+                TIMESTAMP_MICROSECONDS,
+                sqlTimestampOf(micros, session.toConnectorSession(), TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testNarrowingCast()
+    {
+        // CAST(TIMESTAMP(6) AS TIMESTAMP(3)) with exact millisecond value (no truncation needed)
+        SqlTimestamp ts3 = sqlTimestampOf(2001, 8, 22, 3, 4, 5, 321, session);
+        assertFunction(
+                "CAST(CAST(TIMESTAMP '2001-08-22 03:04:05.321' AS TIMESTAMP(6)) AS TIMESTAMP(3))",
+                TIMESTAMP,
+                ts3);
+    }
+
+    @Test
+    public void testFloorTruncationOnPositive()
+    {
+        // CAST(TIMESTAMP(6) AS TIMESTAMP(3)): 999 ms widens to 999_000 μs, truncates back to 999 ms
+        SqlTimestamp ts3 = sqlTimestampOf(1970, 1, 1, 0, 0, 0, 999, session);
+        assertFunction(
+                "CAST(CAST(TIMESTAMP '1970-01-01 00:00:00.999' AS TIMESTAMP(6)) AS TIMESTAMP(3))",
+                TIMESTAMP,
+                ts3);
+    }
+
+    @Test
+    public void testFloorTruncationOnNegative()
+    {
+        // CAST(TIMESTAMP(6) AS TIMESTAMP(3)): -1 ms → -1000 μs → floor(-1000/1000) = -1 ms
+        SqlTimestamp ts3 = sqlTimestampOf(1969, 12, 31, 23, 59, 59, 999, session);
+        assertFunction(
+                "CAST(CAST(TIMESTAMP '1969-12-31 23:59:59.999' AS TIMESTAMP(6)) AS TIMESTAMP(3))",
+                TIMESTAMP,
+                ts3);
+    }
+
+    @Test
+    public void testWideningThenNarrowingRoundTrip()
+    {
+        // Round-trip through higher precision should give back the original value
+        SqlTimestamp ts3 = sqlTimestampOf(2001, 8, 22, 3, 4, 5, 321, session);
+        assertFunction(
+                "CAST(CAST(CAST(TIMESTAMP '2001-08-22 03:04:05.321' AS TIMESTAMP(6)) AS TIMESTAMP(3)) AS TIMESTAMP(6))",
+                TIMESTAMP_MICROSECONDS,
+                sqlTimestampOf(ts3.getMicros(), session.toConnectorSession(), TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testShortToShortCastArithmetic()
+    {
+        // Direct unit test of shortToShortCast arithmetic
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(1000L, 3, 6), 1_000_000L);  // ms→μs: *1000
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(1_000_000L, 6, 3), 1000L);  // μs→ms: /1000
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(-1L, 3, 6), -1000L);         // negative ms→μs
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(-999L, 6, 3), -1L);          // floor(-999/1000)=-1
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(-1000L, 6, 3), -1L);         // exact boundary
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(-1001L, 6, 3), -2L);         // floor(-1001/1000)=-2
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(0L, 3, 6), 0L);              // epoch zero
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(999L, 3, 0), 0L);            // ms→s floor(0.999)=0
+        assertEquals(TimestampPrecisionCasts.shortToShortCast(-1L, 3, 0), -1L);            // floor(-0.001)=-1
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -695,7 +695,7 @@ public class OrcWriteValidation
                 }
             }
 
-            if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP_MICROSECONDS)) {
+            if (type == TIMESTAMP_MICROSECONDS) {
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -21,7 +21,6 @@ import com.facebook.presto.common.block.ColumnarRow;
 import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
-import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.metadata.CompressionKind;
@@ -685,7 +684,7 @@ public class OrcWriteValidation
                 return hash;
             }
 
-            if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP)) {
+            if (type == TIMESTAMP) {
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000, exclusive, and 1970-01-01 00:00:00.000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -502,6 +502,7 @@ type
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
     | ROW '(' identifier type (',' identifier type)* ')'
+    | TIMESTAMP '(' typeParameter ')' WITH TIME ZONE
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
     | INTERVAL from=intervalField TO to=intervalField
     ;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2973,6 +2973,11 @@ class AstBuilder
 
     private String getType(SqlBaseParser.TypeContext type)
     {
+        // TIMESTAMP(p) WITH TIME ZONE — precision-parameterized timezone-aware timestamp
+        if (type.TIMESTAMP() != null) {
+            return "timestamp with time zone(" + typeParameterToString(type.typeParameter(0)) + ")";
+        }
+
         if (type.baseType() != null) {
             String signature = type.baseType().getText();
             if (type.baseType().DOUBLE_PRECISION() != null) {

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -401,8 +401,15 @@ public class TestSqlParser
         assertCast("date");
         assertCast("time");
         assertCast("timestamp");
+        assertCast("timestamp(3)");
+        assertCast("timestamp(6)");
+        assertCast("timestamp(9)");
         assertCast("time with time zone");
         assertCast("timestamp with time zone");
+        assertCast("timestamp(3) with time zone", "timestamp with time zone(3)");
+        assertCast("timestamp(6) with time zone", "timestamp with time zone(6)");
+        assertCast("timestamp(9) with time zone", "timestamp with time zone(9)");
+        assertCast("TIMESTAMP(9) WITH TIME ZONE", "timestamp with time zone(9)");
         assertCast("foo");
         assertCast("FOO");
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add precision-aware timestamp and timestamp-with-time-zone support, including casting and type resolution, and extend tests for timestamp precision behavior.

New Features:
- Support precision-parameterized TIMESTAMP(p) WITH TIME ZONE in the SQL grammar, AST, and type system.
- Introduce scalar casts between TIMESTAMP(p1) and TIMESTAMP(p2) for short precisions with defined widening and narrowing semantics.

Enhancements:
- Improve type cast error reporting to surface detailed precision range violations to users.
- Extend type coercion to compute common supertypes for TIMESTAMP types based on maximum precision.
- Register the parametric TIMESTAMP WITH TIME ZONE type and associated timestamp cast function in the built-in type and function registry.
- Use standard library Integer.min for list comparison length in expression equivalence.

Tests:
- Add parser tests for precision-parameterized timestamp and timestamp-with-time-zone casts.
- Add type compatibility tests for TIMESTAMP types with different precisions.
- Add unit tests covering timestamp precision cast arithmetic and round-trip behavior across precisions.