### PR TITLE
feat: Update TimestampType to use epoch methods for precision handling

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -16,104 +16,208 @@ package com.facebook.presto.common.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+// Short precisions (p=0–6) are stored as a single epoch-scaled long. The stored value equals the
+// number of units elapsed since 1970-01-01T00:00:00 UTC — e.g. p=3 stores epoch-milliseconds and
+// p=6 stores epoch-microseconds.
 //
-// TIMESTAMP is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-// TIMESTAMP_MICROSECONDS is stored as microseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
+// Long precisions (p=7–12) will use a two-field LongTimestamp representation (epochMicros + picosOfMicro)
+// once that type is introduced in a follow-up change (see github.com/prestodb/presto/issues/27934).
+// Instances for p=7–12 are pre-allocated here but their arithmetic helpers throw
+// UnsupportedOperationException until the LongTimestamp path is wired in.
 public final class TimestampType
         extends AbstractLongType
 {
-    public static final TimestampType TIMESTAMP = new TimestampType(MILLISECONDS);
-    public static final TimestampType TIMESTAMP_MICROSECONDS = new TimestampType(MICROSECONDS);
+    public static final int MAX_PRECISION = 12;
+    public static final int MAX_SHORT_PRECISION = 6;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private final TimeUnit precision;
+    private static final long[] PRECISION_SCALE = {
+            1L,                     // p=0  (seconds)
+            10L,                    // p=1
+            100L,                   // p=2
+            1_000L,                 // p=3  (milliseconds)
+            10_000L,                // p=4
+            100_000L,               // p=5
+            1_000_000L,             // p=6  (microseconds)
+            10_000_000L,            // p=7
+            100_000_000L,           // p=8
+            1_000_000_000L,         // p=9  (nanoseconds)
+            10_000_000_000L,        // p=10
+            100_000_000_000L,       // p=11
+            1_000_000_000_000L,     // p=12 (picoseconds)
+    };
 
-    private TimestampType(TimeUnit precision)
+    private static final TimestampType[] INSTANCES = new TimestampType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampType(p);
+        }
+    }
+
+    public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
+
+    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
+    // on type-signature base strings continues to work without changes.
+    public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
+
+    private final int precision;
+
+    // Returns the interned instance for p=0..MAX_PRECISION. Only p=3 and p=6 are registered in
+    // the type manager; all other precisions are arithmetic-only until a follow-up change wires
+    // full type-system support (see github.com/prestodb/presto/issues/27934).
+    public static TimestampType createTimestampType(int precision)
     {
-        super(parseTypeSignature(getType(precision)));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
         this.precision = precision;
     }
 
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP);
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            // Preserve "timestamp microseconds" for the same reason.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
+    }
+
+    // Only p=3 and p=6 are supported; all other precisions throw UnsupportedOperationException.
+    // Support for p=0–2, p=4–5, and p=7–12 is planned for a follow-up change.
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
-
+        if (precision != DEFAULT_PRECISION && precision != MAX_SHORT_PRECISION) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + ")");
+        }
+        TimeUnit unit = toTimeUnit(precision);
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), precision);
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
         }
-        else {
-            return new SqlTimestamp(block.getLong(position), precision);
-        }
+        return new SqlTimestamp(block.getLong(position), unit);
     }
 
-    public TimeUnit getPrecision()
+    // True when the value fits in a single long (p <= MAX_SHORT_PRECISION). Storage concept only —
+    // short precisions other than p=3 and p=6 are not yet registered in the type manager.
+    public boolean isShort()
     {
-        return this.precision;
+        return precision <= MAX_SHORT_PRECISION;
     }
 
+    // Used to distinguish millisecond-precision timestamps (e.g. PartitionTable Iceberg partition
+    // value conversion, and future JDBC/ORC paths).
+    public boolean isMillisPrecision()
+    {
+        return precision == DEFAULT_PRECISION;
+    }
+
+    // Instances are interned (one per precision, 0–MAX_PRECISION), so reference equality is correct.
+    // Both methods are overridden solely to satisfy the checkstyle EqualsHashCode rule; the default
+    // Object implementations would behave identically.
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        if (precision == MICROSECONDS) {
-            return other == TIMESTAMP_MICROSECONDS;
-        }
-        if (precision == MILLISECONDS) {
-            return other == TIMESTAMP;
-        }
-        throw new UnsupportedOperationException("Unsupported precision " + precision);
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getClass(), precision);
+        return System.identityHashCode(this);
     }
 
-    /**
-     * Gets the timestamp's number of total seconds.
-     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
-     *
-     * Returns:
-     * the total seconds in timestamp
-     */
+    // Floor division gives the correct epoch-second for negative (pre-1970) timestamps.
     public long getEpochSecond(long timestamp)
     {
-        return this.precision.toSeconds(timestamp);
+        return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
-    /**
-     * Gets the timestamp's nanosecond portion.
-     *
-     * Returns:
-     * this timestamp's fractional seconds component
-     */
+    // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
-        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
-        return (int) precision.toNanos(timestamp % unitsPerSecond);
+        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
+        long scale = PRECISION_SCALE[precision];
+        // For p <= 9, scale <= 1e9: multiply up to nanoseconds.
+        // For p > 9, scale > 1e9: dividing avoids integer overflow; scale is always a multiple of 1e9.
+        if (scale <= 1_000_000_000L) {
+            return (int) (fractional * (1_000_000_000L / scale));
+        }
+        return (int) (fractional / (scale / 1_000_000_000L));
     }
 
-    private static String getType(TimeUnit precision)
+    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
+    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    public long toEpochMillis(long timestamp)
     {
-        if (precision == MICROSECONDS) {
-            return StandardTypes.TIMESTAMP_MICROSECONDS;
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "toEpochMillis is not supported for TIMESTAMP(" + precision + ")");
         }
-        if (precision == MILLISECONDS) {
-            return StandardTypes.TIMESTAMP;
+        return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
+    }
+
+    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
+    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    public long toEpochMicros(long timestamp)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "toEpochMicros is not supported for TIMESTAMP(" + precision + ")");
         }
-        throw new IllegalArgumentException("Unsupported precision " + precision);
+        return getEpochSecond(timestamp) * 1_000_000L + getNanos(timestamp) / 1_000;
+    }
+
+    public long fromEpochComponents(long epochSecond, int nanos)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "fromEpochComponents is not supported for TIMESTAMP(" + precision + ")");
+        }
+        if (nanos < 0 || nanos >= 1_000_000_000) {
+            throw new IllegalArgumentException("nanos must be in range [0, 999_999_999]: " + nanos);
+        }
+        long scale = PRECISION_SCALE[precision];
+        return epochSecond * scale + nanos / (1_000_000_000L / scale);
+    }
+
+    private static TimeUnit toTimeUnit(int precision)
+    {
+        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
+        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
+        if (precision == DEFAULT_PRECISION) {
+            return MILLISECONDS;
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            return MICROSECONDS;
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported precision for TimeUnit conversion: TIMESTAMP(" + precision + ")");
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampType
+{
+    @Test
+    public void testInterningReturnsSameReference()
+    {
+        for (int p = 0; p <= TimestampType.MAX_PRECISION; p++) {
+            assertSame(createTimestampType(p), createTimestampType(p),
+                    "createTimestampType(" + p + ") must return the same reference on repeated calls");
+        }
+    }
+
+    @Test
+    public void testConstantsAreInterned()
+    {
+        assertSame(createTimestampType(3), TIMESTAMP);
+        assertSame(createTimestampType(6), TIMESTAMP_MICROSECONDS);
+    }
+
+    @Test
+    public void testIsShortBoundary()
+    {
+        for (int p = 0; p <= TimestampType.MAX_SHORT_PRECISION; p++) {
+            assertTrue(createTimestampType(p).isShort(), "isShort() must return true for p=" + p);
+        }
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            assertFalse(createTimestampType(p).isShort(), "isShort() must return false for p=" + p);
+        }
+    }
+
+    @Test
+    public void testInvalidPrecision()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MIN_VALUE));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MAX_VALUE));
+
+        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        assertTrue(e1.getMessage().contains("-1"));
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        assertTrue(e2.getMessage().contains("13"));
+    }
+
+    @Test
+    public void testReferenceEqualityIsTypeEquality()
+    {
+        for (int p1 = 0; p1 <= TimestampType.MAX_PRECISION; p1++) {
+            for (int p2 = 0; p2 <= TimestampType.MAX_PRECISION; p2++) {
+                if (p1 == p2) {
+                    assertEquals(createTimestampType(p1), createTimestampType(p2));
+                }
+                else {
+                    assertFalse(createTimestampType(p1).equals(createTimestampType(p2)),
+                            "Types with different precision must not be equal");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testEpochComponentsMillis()
+    {
+        TimestampType ts = createTimestampType(3);
+        assertEquals(ts.getEpochSecond(1_000L), 1L);
+        assertEquals(ts.getNanos(1_000L), 0);
+        assertEquals(ts.getEpochSecond(1_500L), 1L);
+        assertEquals(ts.getNanos(1_500L), 500_000_000);
+        // Pre-1970 timestamps: floor division gives the correct epoch-second.
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_000_000);
+    }
+
+    @Test
+    public void testEpochComponentsMicros()
+    {
+        TimestampType ts = createTimestampType(6);
+        assertEquals(ts.getEpochSecond(1_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000L), 0);
+        assertEquals(ts.getEpochSecond(1_500_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000L), 500_000_000);
+        // Floor division: pre-epoch correctness.
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_000);
+    }
+
+    @Test
+    public void testEpochComponentsSeconds()
+    {
+        TimestampType ts = createTimestampType(0);
+        assertEquals(ts.getEpochSecond(5L), 5L);
+        assertEquals(ts.getNanos(5L), 0);
+        assertEquals(ts.toEpochMillis(5L), 5_000L);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 0);
+        assertEquals(ts.toEpochMillis(-1L), -1_000L);
+    }
+
+    @Test
+    public void testEpochComponentsIntermediatePrecision()
+    {
+        // p=4: unit = 100µs (1/10,000 of a second)
+        TimestampType ts = createTimestampType(4);
+        assertEquals(ts.getEpochSecond(10_000L), 1L);
+        assertEquals(ts.getNanos(10_000L), 0);
+        assertEquals(ts.getEpochSecond(15_000L), 1L);
+        assertEquals(ts.getNanos(15_000L), 500_000_000);
+        assertEquals(ts.toEpochMillis(10_000L), 1_000L);
+        assertEquals(ts.toEpochMillis(15_000L), 1_500L);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_900_000);
+    }
+
+    @Test
+    public void testToEpochMillis()
+    {
+        assertEquals(createTimestampType(3).toEpochMillis(1_500L), 1_500L);
+        assertEquals(createTimestampType(6).toEpochMillis(1_500_000L), 1_500L);
+        // Pre-epoch: floor division — old MICROSECONDS.toMillis(-1µs) returned 0, not -1.
+        assertEquals(createTimestampType(3).toEpochMillis(-1L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-1L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-999L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-1_000L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-1_001L), -2L);
+        assertEquals(createTimestampType(3).toEpochMillis(Long.MIN_VALUE / 1_000 * 1_000), Long.MIN_VALUE / 1_000 * 1_000);
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).toEpochMillis(0L));
+    }
+
+    @Test
+    public void testToEpochMicros()
+    {
+        assertEquals(createTimestampType(0).toEpochMicros(1L), 1_000_000L);
+        assertEquals(createTimestampType(0).toEpochMicros(0L), 0L);
+        assertEquals(createTimestampType(0).toEpochMicros(-1L), -1_000_000L);
+        assertEquals(createTimestampType(3).toEpochMicros(1_500L), 1_500_000L);
+        assertEquals(createTimestampType(3).toEpochMicros(0L), 0L);
+        // Pre-epoch: IcebergPageSink uses toEpochMicros for p=3 (millis → micros).
+        assertEquals(createTimestampType(3).toEpochMicros(-1L), -1_000L);
+        assertEquals(createTimestampType(3).toEpochMicros(-1_000L), -1_000_000L);
+        assertEquals(createTimestampType(3).toEpochMicros(-1_001L), -1_001_000L);
+        assertEquals(createTimestampType(6).toEpochMicros(1_500_000L), 1_500_000L);
+        assertEquals(createTimestampType(6).toEpochMicros(-1L), -1L);
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).toEpochMicros(0L));
+    }
+
+    @Test
+    public void testFromEpochComponents()
+    {
+        TimestampType millis = createTimestampType(3);
+        assertEquals(millis.fromEpochComponents(1L, 500_000_000), 1_500L);
+        assertEquals(millis.fromEpochComponents(0L, 0), 0L);
+        assertEquals(millis.fromEpochComponents(-1L, 999_000_000), -1L);
+
+        TimestampType micros = createTimestampType(6);
+        assertEquals(micros.fromEpochComponents(1L, 500_000_000), 1_500_000L);
+
+        expectThrows(IllegalArgumentException.class, () -> millis.fromEpochComponents(0L, -1));
+        expectThrows(IllegalArgumentException.class, () -> millis.fromEpochComponents(0L, 1_000_000_000));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).fromEpochComponents(0L, 0));
+    }
+
+    @Test
+    public void testLongPrecisionEpochHelpersThrow()
+    {
+        // toEpochMillis, toEpochMicros, and fromEpochComponents require a single-long representation
+        // and throw for p > MAX_SHORT_PRECISION until LongTimestamp is wired in.
+        // getEpochSecond and getNanos do not guard on precision — those guards arrive with LongTimestamp.
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            TimestampType ts = createTimestampType(p);
+            expectThrows(UnsupportedOperationException.class, () -> ts.toEpochMillis(0L));
+            expectThrows(UnsupportedOperationException.class, () -> ts.toEpochMicros(0L));
+            expectThrows(UnsupportedOperationException.class, () -> ts.fromEpochComponents(0L, 0));
+        }
+    }
+
+    @Test
+    public void testGetObjectValue()
+    {
+        SqlFunctionProperties nonLegacy = SqlFunctionProperties.builder()
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(false)
+                .setSessionLocale(Locale.ENGLISH)
+                .setSessionUser("test")
+                .build();
+        SqlFunctionProperties legacy = SqlFunctionProperties.builder()
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(true)
+                .setSessionLocale(Locale.ENGLISH)
+                .setSessionUser("test")
+                .build();
+
+        BlockBuilder millisBuilder = TIMESTAMP.createBlockBuilder(null, 1);
+        TIMESTAMP.writeLong(millisBuilder, 1_000L);
+        Block millisBlock = millisBuilder.build();
+        assertEquals(TIMESTAMP.getObjectValue(nonLegacy, millisBlock, 0), new SqlTimestamp(1_000L, MILLISECONDS));
+        assertEquals(TIMESTAMP.getObjectValue(legacy, millisBlock, 0), new SqlTimestamp(1_000L, TimeZoneKey.UTC_KEY, MILLISECONDS));
+
+        BlockBuilder microsBuilder = TIMESTAMP_MICROSECONDS.createBlockBuilder(null, 1);
+        TIMESTAMP_MICROSECONDS.writeLong(microsBuilder, 1_000_000L);
+        Block microsBlock = microsBuilder.build();
+        assertEquals(TIMESTAMP_MICROSECONDS.getObjectValue(nonLegacy, microsBlock, 0), new SqlTimestamp(1_000_000L, MICROSECONDS));
+        assertEquals(TIMESTAMP_MICROSECONDS.getObjectValue(legacy, microsBlock, 0), new SqlTimestamp(1_000_000L, TimeZoneKey.UTC_KEY, MICROSECONDS));
+
+        // Build a non-null block so the precision check is reached (null position returns early).
+        BlockBuilder builder = TIMESTAMP.createBlockBuilder(null, 1);
+        TIMESTAMP.writeLong(builder, 1_000L);
+        Block block = builder.build();
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(1).getObjectValue(null, block, 0));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(4).getObjectValue(null, block, 0));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).getObjectValue(null, block, 0));
+    }
+
+    @Test
+    public void testRoundTripFromEpochComponents()
+    {
+        // fromEpochComponents(getEpochSecond(v), getNanos(v)) must reconstruct v exactly.
+        // IcebergPageSink relies on this invariant when converting legacy-timezone timestamps.
+        long[] milliValues = {
+                0L, 1L, 1_000L, 1_500L, 999L,
+                -1L, -1_000L, -1_001L, -1_500L,
+                Long.MAX_VALUE / 1_000 * 1_000,
+        };
+        TimestampType millis = createTimestampType(3);
+        for (long v : milliValues) {
+            assertEquals(millis.fromEpochComponents(millis.getEpochSecond(v), (int) millis.getNanos(v)), v,
+                    "round-trip failed for p=3, v=" + v);
+        }
+
+        long[] microValues = {
+                0L, 1L, 1_000_000L, 1_500_000L, 999_999L,
+                -1L, -1_000_000L, -1_000_001L, -1_500_000L,
+        };
+        TimestampType micros = createTimestampType(6);
+        for (long v : microValues) {
+            assertEquals(micros.fromEpochComponents(micros.getEpochSecond(v), (int) micros.getNanos(v)), v,
+                    "round-trip failed for p=6, v=" + v);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1750,7 +1750,7 @@ public abstract class IcebergAbstractMetadata
             }
             else if (tableVersion.getVersionExpressionType() instanceof TimestampType) {
                 long timestampValue = (long) tableVersion.getTableVersion();
-                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
+                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).toEpochMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
             else if (tableVersion.getVersionExpressionType() instanceof BigintType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -93,8 +93,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -547,8 +545,9 @@ public class IcebergPageSink
             return type.getSlice(block, position).toStringUtf8();
         }
         if (type instanceof TimestampType) {
-            long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+            // Iceberg expects epoch-microseconds. toEpochMicros converts both TIMESTAMP (p=3, millis)
+            // and TIMESTAMP_MICROSECONDS (p=6, micros) to the required unit.
+            return ((TimestampType) type).toEpochMicros(type.getLong(block, position));
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -562,14 +561,13 @@ public class IcebergPageSink
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
-            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
-                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            Instant instant = Instant.ofEpochSecond(timestampType.getEpochSecond(timestampValue),
+                    timestampType.getNanos(timestampValue));
             LocalDateTime localDateTime = instant
                     .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
                     .toLocalDateTime();
 
-            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
-                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+            return timestampType.fromEpochComponents(localDateTime.toEpochSecond(ZoneOffset.UTC), localDateTime.getNano());
         }
         return value;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -64,7 +64,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
 public class PartitionTable
@@ -320,8 +319,11 @@ public class PartitionTable
         }
         if (type instanceof Types.TimestampType) {
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
-            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
-                return MICROSECONDS.toMillis((long) value);
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).isMillisPrecision()) {
+                // Iceberg stores partition timestamps as epoch-microseconds; convert to
+                // epoch-milliseconds for the TIMESTAMP (p=3) mapping. Uses floor division so
+                // pre-1970 values are correct (TimeUnit.MICROSECONDS.toMillis() would truncate).
+                return TimestampType.TIMESTAMP_MICROSECONDS.toEpochMillis((long) value);
             }
         }
         if (type instanceof Types.TimeType) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -573,7 +573,7 @@ public class IOPlanPrinter
             }
             if (type instanceof TimestampType) {
                 TimestampType timestampType = (TimestampType) type;
-                long timestampValue = timestampType.getPrecision().toMillis((Long) value);
+                long timestampValue = timestampType.toEpochMillis((Long) value);
                 return printTimestampWithoutTimeZone(timestampValue);
             }
             if (type instanceof TimestampWithTimeZoneType) {

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarTimestampTypes.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarTimestampTypes.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end native sidecar tests for TIMESTAMP type handling.
+ */
+public class TestNativeSidecarTimestampTypes
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setCoordinatorSidecarEnabled(true)
+                .build();
+        TestNativeSidecarPlugin.setupNativeSidecarPlugin(queryRunner);
+        return queryRunner;
+    }
+
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testPreEpochTimestampDecomposition()
+    {
+        assertQuery("SELECT year(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT month(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT day(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT hour(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT minute(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT second(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT millisecond(TIMESTAMP '1969-12-31 23:59:59.999')");
+    }
+
+    @Test
+    public void testPreEpochTimestampToUnixtime()
+    {
+        assertQuery("SELECT to_unixtime(TIMESTAMP '1969-12-31 23:59:59.999')");
+        assertQuery("SELECT to_unixtime(TIMESTAMP '1969-12-31 23:59:59.000')");
+        assertQuery("SELECT to_unixtime(TIMESTAMP '1969-12-31 23:59:58.999')");
+        assertQuery("SELECT to_unixtime(TIMESTAMP '1970-01-01 00:00:00.000')");
+    }
+
+    @Test
+    public void testPreEpochTimestampArithmetic()
+    {
+        assertQuery("SELECT date_diff('millisecond', TIMESTAMP '1969-12-31 23:59:59.000', TIMESTAMP '1970-01-01 00:00:01.000')");
+        assertQuery("SELECT date_add('millisecond', -1, TIMESTAMP '1970-01-01 00:00:00.000')");
+        assertQuery("SELECT date_add('day', -1, TIMESTAMP '1970-01-01 00:00:00.000')");
+    }
+
+    @Test
+    public void testParameterizedTimestampNotSupported()
+    {
+        String[][] cases = {
+                {"0", "2021-01-01 00:00:00"},
+                {"1", "2021-01-01 00:00:00.1"},
+                {"2", "2021-01-01 00:00:00.12"},
+                {"3", "2021-01-01 00:00:00.123"},
+                {"4", "2021-01-01 00:00:00.1234"},
+                {"5", "2021-01-01 00:00:00.12345"},
+                {"6", "2021-01-01 00:00:00.123456"},
+                {"7", "2021-01-01 00:00:00.1234567"},
+                {"9", "2021-01-01 00:00:00.123456789"},
+                {"12", "2021-01-01 00:00:00.123456789012"},
+        };
+        for (String[] c : cases) {
+            assertQueryFails(
+                    "SELECT CAST('" + c[1] + "' AS TIMESTAMP(" + c[0] + "))",
+                    "line 1:8: Unknown type: timestamp\\(" + c[0] + "\\)");
+        }
+    }
+}


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refine TIMESTAMP type precision handling around epoch-based components and integrate the new APIs into Iceberg-related code and plan printing.

Enhancements:
- Generalize TimestampType to support precision parameters 0–12 with interned instances, expose epoch-based helper methods, and change equality semantics to reference equality per precision.
- Update Iceberg partition conversion, page sink, metadata snapshot resolution, and IO plan printing to use the new TimestampType precision constants and epoch helper methods instead of raw TimeUnit conversions.

Tests:
- Add TestTimestampType to validate interning, precision and short/long boundaries, epoch second/nanos calculations across precisions, and conversion to epoch milliseconds.

## Summary by Sourcery

Extend TIMESTAMP type to support precision-aware epoch-based operations and align Iceberg integrations and plan printing with the new APIs.

New Features:
- Introduce precision-parameterized TimestampType instances for p=0–12 with interned singletons and helper methods for epoch-based conversions and reconstruction of timestamp values.

Enhancements:
- Adjust TimestampType equality semantics to rely on reference identity per precision and add helpers for determining short/long storage and millisecond precision.
- Update Iceberg page sink, partition table conversion, snapshot resolution, and IO plan printing to use TimestampType epoch helper methods instead of raw TimeUnit conversions, improving correctness for pre-epoch timestamps.

Tests:
- Add comprehensive TestTimestampType coverage for precision interning, short/long boundaries, epoch second/nanos behavior across precisions, epoch millis/micros conversion, fromEpochComponents round-tripping, getObjectValue behavior, and unsupported precision guards.