### PR TITLE
Core type1p

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -20,60 +20,156 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-//
-// TIMESTAMP is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-// TIMESTAMP_MICROSECONDS is stored as microseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
+// All precisions are stored as a single epoch-scaled long. The stored value equals the number of
+// units (determined by precision) elapsed since 1970-01-01T00:00:00 UTC. For example, p=3 stores
+// epoch-milliseconds and p=6 stores epoch-microseconds. Precisions above p=6 are accepted but the
+// long range limits the representable window (e.g. p=12 fits roughly +/-2562 years from epoch).
 public final class TimestampType
         extends AbstractLongType
 {
-    public static final TimestampType TIMESTAMP = new TimestampType(MILLISECONDS);
-    public static final TimestampType TIMESTAMP_MICROSECONDS = new TimestampType(MICROSECONDS);
+    public static final int MAX_PRECISION = 12;
+    public static final int MAX_SHORT_PRECISION = 6;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private final TimeUnit precision;
+    private static final long[] PRECISION_SCALE = {
+            1L,                     // p=0  (seconds)
+            10L,                    // p=1
+            100L,                   // p=2
+            1_000L,                 // p=3  (milliseconds)
+            10_000L,                // p=4
+            100_000L,               // p=5
+            1_000_000L,             // p=6  (microseconds)
+            10_000_000L,            // p=7
+            100_000_000L,           // p=8
+            1_000_000_000L,         // p=9  (nanoseconds)
+            10_000_000_000L,        // p=10
+            100_000_000_000L,       // p=11
+            1_000_000_000_000L,     // p=12 (picoseconds)
+    };
 
-    private TimestampType(TimeUnit precision)
+    private static final TimestampType[] INSTANCES = new TimestampType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampType(p);
+        }
+    }
+
+    public static final TimestampType TIMESTAMP = INSTANCES[DEFAULT_PRECISION];
+
+    // Keeps the legacy "timestamp microseconds" type signature so existing code that matches
+    // on type-signature base strings continues to work without changes.
+    public static final TimestampType TIMESTAMP_MICROSECONDS = INSTANCES[MAX_SHORT_PRECISION];
+
+    private final int precision;
+
+    /**
+     * Returns the interned {@link TimestampType} for the given precision (0–{@link #MAX_PRECISION}).
+     *
+     * <p><b>Type-system support matrix (as of this change):</b>
+     * <ul>
+     *   <li>p=3 ({@link #TIMESTAMP}) and p=6 ({@link #TIMESTAMP_MICROSECONDS}) are fully wired:
+     *       registered in the type manager, round-trippable via type signature, and supported by
+     *       {@link #getObjectValue}.</li>
+     *   <li>All precisions support the arithmetic helpers ({@link #getEpochSecond},
+     *       {@link #getNanos}, {@link #toEpochMillis}, {@link #toEpochMicros},
+     *       {@link #fromEpochComponents}) subject to their own preconditions.</li>
+     *   <li>All other precisions (p=0–2, p=4–5, p=7–12) are <em>not</em> registered in the type
+     *       manager and are not recognized from a parsed type-signature string. Their
+     *       {@link #getObjectValue} throws {@link UnsupportedOperationException}. Full type-system
+     *       integration is planned for a follow-up change.</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if {@code precision} is outside [0, {@link #MAX_PRECISION}]
+     */
+    public static TimestampType createTimestampType(int precision)
     {
-        super(parseTypeSignature(getType(precision)));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
         this.precision = precision;
     }
 
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP);
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            // Preserve "timestamp microseconds" for the same reason.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of((long) precision));
+    }
+
+    /**
+     * Returns a {@link SqlTimestamp} for the value at {@code position}.
+     *
+     * <p>Only {@link #DEFAULT_PRECISION} (p=3, milliseconds) and {@link #MAX_SHORT_PRECISION}
+     * (p=6, microseconds) are supported; all other precisions throw
+     * {@link UnsupportedOperationException}. Support for the remaining short precisions
+     * (p=0–2, p=4–5) and long precisions (p=7–12) is planned for a follow-up change.
+     */
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
-
+        if (precision != DEFAULT_PRECISION && precision != MAX_SHORT_PRECISION) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + ")");
+        }
+        TimeUnit unit = toTimeUnit(precision);
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), precision);
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
         }
-        else {
-            return new SqlTimestamp(block.getLong(position), precision);
-        }
+        return new SqlTimestamp(block.getLong(position), unit);
     }
 
-    public TimeUnit getPrecision()
+    /**
+     * Returns {@code true} when the timestamp value fits in a single {@code long} (p ≤ {@link #MAX_SHORT_PRECISION}).
+     *
+     * <p>This is a <em>storage representation</em> concept. It does <em>not</em> imply full API support:
+     * short precisions other than p=3 and p=6 are not registered in the type manager and their
+     * {@link #getObjectValue} throws {@link UnsupportedOperationException}. See {@link #createTimestampType}
+     * for the complete support matrix.
+     */
+    public boolean isShort()
     {
-        return this.precision;
+        return precision <= MAX_SHORT_PRECISION;
     }
 
+    // Scaffolding for follow-up work that needs to distinguish millisecond-precision timestamps
+    // (e.g. legacy JDBC write paths, ORC column statistics). Not yet used within this change.
+    public boolean isMillisPrecision()
+    {
+        return precision == DEFAULT_PRECISION;
+    }
+
+    // Instances are interned, so reference equality is correct. equals() and hashCode() are both
+    // overridden to satisfy the checkstyle EqualsHashCode rule. hashCode() uses precision rather
+    // than identity to produce a stable, deterministic value across JVM runs.
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        if (precision == MICROSECONDS) {
-            return other == TIMESTAMP_MICROSECONDS;
-        }
-        if (precision == MILLISECONDS) {
-            return other == TIMESTAMP;
-        }
-        throw new UnsupportedOperationException("Unsupported precision " + precision);
+        return this == other;
     }
 
     @Override
@@ -82,38 +178,73 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
-    /**
-     * Gets the timestamp's number of total seconds.
-     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
-     *
-     * Returns:
-     * the total seconds in timestamp
-     */
+    // Floor division handles negative (pre-1970) timestamps correctly.
+    // The prior implementation used TimeUnit.toSeconds(), which truncates toward zero and incorrectly
+    // returned 0 for any timestamp in the range (-1s, 0) — e.g. getEpochSecond(-1ms) was 0, not -1.
     public long getEpochSecond(long timestamp)
     {
-        return this.precision.toSeconds(timestamp);
+        return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
-    /**
-     * Gets the timestamp's nanosecond portion.
-     *
-     * Returns:
-     * this timestamp's fractional seconds component
-     */
+    // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
-        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
-        return (int) precision.toNanos(timestamp % unitsPerSecond);
+        long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
+        long scale = PRECISION_SCALE[precision];
+        // For p <= 9, scale <= 1e9: multiply up to nanoseconds.
+        // For p > 9, scale > 1e9: dividing avoids integer overflow; scale is always a multiple of 1e9.
+        if (scale <= 1_000_000_000L) {
+            return (int) (fractional * (1_000_000_000L / scale));
+        }
+        return (int) (fractional / (scale / 1_000_000_000L));
     }
 
-    private static String getType(TimeUnit precision)
+    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
+    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    public long toEpochMillis(long timestamp)
     {
-        if (precision == MICROSECONDS) {
-            return StandardTypes.TIMESTAMP_MICROSECONDS;
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "toEpochMillis is not supported for TIMESTAMP(" + precision + ")");
         }
-        if (precision == MILLISECONDS) {
-            return StandardTypes.TIMESTAMP;
+        return getEpochSecond(timestamp) * 1_000L + getNanos(timestamp) / 1_000_000;
+    }
+
+    // Supported for all short precisions (p=0 through p=6, i.e. isShort()==true).
+    // Long precisions (p=7-12) require a 128-bit representation and are not yet supported.
+    public long toEpochMicros(long timestamp)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "toEpochMicros is not supported for TIMESTAMP(" + precision + ")");
         }
-        throw new IllegalArgumentException("Unsupported precision " + precision);
+        return getEpochSecond(timestamp) * 1_000_000L + getNanos(timestamp) / 1_000;
+    }
+
+    public long fromEpochComponents(long epochSecond, int nanos)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "fromEpochComponents is not supported for TIMESTAMP(" + precision + ")");
+        }
+        if (nanos < 0 || nanos >= 1_000_000_000) {
+            throw new IllegalArgumentException("nanos must be in range [0, 999_999_999]: " + nanos);
+        }
+        long scale = PRECISION_SCALE[precision];
+        return epochSecond * scale + nanos / (1_000_000_000L / scale);
+    }
+
+    private static TimeUnit toTimeUnit(int precision)
+    {
+        // Exact-precision checks: DEFAULT_PRECISION (3) stores epoch-millis; MAX_SHORT_PRECISION (6)
+        // stores epoch-micros. Other precisions have no direct TimeUnit mapping.
+        if (precision == DEFAULT_PRECISION) {
+            return MILLISECONDS;
+        }
+        if (precision == MAX_SHORT_PRECISION) {
+            return MICROSECONDS;
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported precision for TimeUnit conversion: TIMESTAMP(" + precision + ")");
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampType
+{
+    @Test
+    public void testInterningReturnsSameReference()
+    {
+        for (int p = 0; p <= TimestampType.MAX_PRECISION; p++) {
+            assertSame(createTimestampType(p), createTimestampType(p),
+                    "createTimestampType(" + p + ") must return same reference on repeated calls");
+        }
+    }
+
+    @Test
+    public void testAllInstancesPreAllocated()
+    {
+        for (int p = 0; p <= TimestampType.MAX_PRECISION; p++) {
+            assertNotNull(createTimestampType(p), "Instance for precision " + p + " must be pre-allocated");
+        }
+    }
+
+    @Test
+    public void testTimestampConstantBackwardCompatibility()
+    {
+        assertSame(TIMESTAMP, createTimestampType(3), "TIMESTAMP must be same reference as createTimestampType(3)");
+    }
+
+    @Test
+    public void testIsShortBoundary()
+    {
+        for (int p = 0; p <= TimestampType.MAX_SHORT_PRECISION; p++) {
+            assertTrue(createTimestampType(p).isShort(), "isShort() must return true for p=" + p);
+        }
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            assertFalse(createTimestampType(p).isShort(), "isShort() must return false for p=" + p);
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MIN_VALUE));
+        expectThrows(IllegalArgumentException.class, () -> createTimestampType(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testInvalidPrecisionErrorMessage()
+    {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createTimestampType(-1));
+        assertTrue(e.getMessage().contains("-1"), "Error message must contain the invalid value");
+
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> createTimestampType(13));
+        assertTrue(e2.getMessage().contains("13"), "Error message must contain the invalid value");
+    }
+
+    @Test
+    public void testTimestampMicrosecondsIsInterned()
+    {
+        assertSame(TIMESTAMP_MICROSECONDS, createTimestampType(6),
+                "TIMESTAMP_MICROSECONDS must be same reference as createTimestampType(6)");
+    }
+
+    @Test
+    public void testReferenceEqualityIsTypeEquality()
+    {
+        for (int p1 = 0; p1 <= TimestampType.MAX_PRECISION; p1++) {
+            for (int p2 = 0; p2 <= TimestampType.MAX_PRECISION; p2++) {
+                if (p1 == p2) {
+                    assertEquals(createTimestampType(p1), createTimestampType(p2));
+                }
+                else {
+                    assertFalse(createTimestampType(p1).equals(createTimestampType(p2)),
+                            "Types with different precision must not be equal");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testEpochComponentsMillis()
+    {
+        TimestampType ts = createTimestampType(3);
+        assertEquals(ts.getEpochSecond(1_000L), 1L);
+        assertEquals(ts.getNanos(1_000L), 0);
+        assertEquals(ts.getEpochSecond(1_500L), 1L);
+        assertEquals(ts.getNanos(1_500L), 500_000_000);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_000_000);
+    }
+
+    @Test
+    public void testToEpochMicros()
+    {
+        assertEquals(createTimestampType(3).toEpochMicros(1_500L), 1_500_000L);
+        assertEquals(createTimestampType(3).toEpochMicros(0L), 0L);
+        assertEquals(createTimestampType(3).toEpochMicros(-1L), -1_000L);
+        assertEquals(createTimestampType(6).toEpochMicros(1_500_000L), 1_500_000L);
+        assertEquals(createTimestampType(6).toEpochMicros(-1L), -1L);
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).toEpochMicros(0L));
+    }
+
+    @Test
+    public void testFromEpochComponents()
+    {
+        TimestampType millis = createTimestampType(3);
+        assertEquals(millis.fromEpochComponents(1L, 500_000_000), 1_500L);
+        assertEquals(millis.fromEpochComponents(0L, 0), 0L);
+        assertEquals(millis.fromEpochComponents(-1L, 999_000_000), -1L);
+
+        TimestampType micros = createTimestampType(6);
+        assertEquals(micros.fromEpochComponents(1L, 500_000_000), 1_500_000L);
+
+        expectThrows(IllegalArgumentException.class, () -> millis.fromEpochComponents(0L, -1));
+        expectThrows(IllegalArgumentException.class, () -> millis.fromEpochComponents(0L, 1_000_000_000));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).fromEpochComponents(0L, 0));
+    }
+
+    @Test
+    public void testEpochComponentsMicros()
+    {
+        TimestampType ts = createTimestampType(6);
+        assertEquals(ts.getEpochSecond(1_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000L), 0);
+        assertEquals(ts.getEpochSecond(1_500_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000L), 500_000_000);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_000);
+    }
+
+    @Test
+    public void testToEpochMillis()
+    {
+        assertEquals(createTimestampType(3).toEpochMillis(1_500L), 1_500L);
+        assertEquals(createTimestampType(6).toEpochMillis(1_500_000L), 1_500L);
+        assertEquals(createTimestampType(3).toEpochMillis(-1L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-1L), -1L);
+        assertEquals(createTimestampType(6).toEpochMillis(-1_000L), -1L);
+    }
+
+    @Test
+    public void testEpochComponentsSeconds()
+    {
+        TimestampType ts = createTimestampType(0);
+        assertEquals(ts.getEpochSecond(5L), 5L);
+        assertEquals(ts.getNanos(5L), 0);
+        assertEquals(ts.toEpochMillis(5L), 5_000L);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 0);
+        assertEquals(ts.toEpochMillis(-1L), -1_000L);
+    }
+
+    @Test
+    public void testEpochComponentsIntermediatePrecision()
+    {
+        // p=4: unit = 100µs (1/10,000 of a second)
+        TimestampType ts = createTimestampType(4);
+        assertEquals(ts.getEpochSecond(10_000L), 1L);
+        assertEquals(ts.getNanos(10_000L), 0);
+        assertEquals(ts.getEpochSecond(15_000L), 1L);
+        assertEquals(ts.getNanos(15_000L), 500_000_000);
+        assertEquals(ts.toEpochMillis(10_000L), 1_000L);
+        assertEquals(ts.toEpochMillis(15_000L), 1_500L);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_900_000);
+    }
+
+    @Test
+    public void testEpochComponentsNanos()
+    {
+        TimestampType ts = createTimestampType(9);
+        assertEquals(ts.getEpochSecond(1_000_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000_000L), 0);
+        assertEquals(ts.getEpochSecond(1_500_000_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000_000L), 500_000_000);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_999);
+    }
+
+    @Test
+    public void testGetObjectValueThrowsForUnsupportedShortPrecisions()
+    {
+        // Build a non-null block so the precision check is reached (null position returns early).
+        BlockBuilder builder = TIMESTAMP.createBlockBuilder(null, 1);
+        TIMESTAMP.writeLong(builder, 1_000L);
+        Block block = builder.build();
+
+        // p=1 and p=4 are short (isShort()==true) but getObjectValue is not yet supported for them.
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(1).getObjectValue(null, block, 0));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(4).getObjectValue(null, block, 0));
+        expectThrows(UnsupportedOperationException.class, () -> createTimestampType(7).getObjectValue(null, block, 0));
+    }
+
+    @Test
+    public void testPreEpochFloorCorrectness()
+    {
+        // Regression guard: the prior implementation used TimeUnit.toSeconds() (truncation toward
+        // zero), which returned 0 for getEpochSecond on any timestamp in (-1s, 0). floorDiv
+        // correctly returns -1.
+        TimestampType millis = createTimestampType(3);
+        assertEquals(millis.getEpochSecond(-1L), -1L);   // was 0 with old truncation
+        assertEquals(millis.getNanos(-1L), 999_000_000); // was 0 - wrong sub-second component
+
+        TimestampType micros = createTimestampType(6);
+        assertEquals(micros.getEpochSecond(-1L), -1L);
+        assertEquals(micros.getNanos(-1L), 999_999_000);
+    }
+
+    @Test
+    public void testRoundTripFromEpochComponents()
+    {
+        // fromEpochComponents(getEpochSecond(v), getNanos(v)) must reconstruct v exactly.
+        // IcebergPageSink relies on this invariant when converting legacy-timezone timestamps.
+        long[] milliValues = {
+                0L,
+                1L,
+                1_000L,
+                1_500L,
+                999L,
+                -1L,
+                -1_000L,
+                -1_001L,
+                -1_500L,
+                Long.MAX_VALUE / 1_000 * 1_000,  // large positive aligned to a whole second
+        };
+        TimestampType millis = createTimestampType(3);
+        for (long v : milliValues) {
+            assertEquals(millis.fromEpochComponents(millis.getEpochSecond(v), (int) millis.getNanos(v)), v,
+                    "round-trip failed for p=3, v=" + v);
+        }
+
+        long[] microValues = {
+                0L,
+                1L,
+                1_000_000L,
+                1_500_000L,
+                999_999L,
+                -1L,
+                -1_000_000L,
+                -1_000_001L,
+                -1_500_000L,
+        };
+        TimestampType micros = createTimestampType(6);
+        for (long v : microValues) {
+            assertEquals(micros.fromEpochComponents(micros.getEpochSecond(v), (int) micros.getNanos(v)), v,
+                    "round-trip failed for p=6, v=" + v);
+        }
+    }
+
+    @Test
+    public void testEpochComponentsPicos()
+    {
+        TimestampType ts = createTimestampType(12);
+        assertEquals(ts.getEpochSecond(1_000_000_000_000L), 1L);
+        assertEquals(ts.getNanos(1_000_000_000_000L), 0);
+        // 500ps is below nanosecond resolution — getNanos rounds down to 0
+        assertEquals(ts.getEpochSecond(1_000_000_000_500L), 1L);
+        assertEquals(ts.getNanos(1_000_000_000_500L), 0);
+        assertEquals(ts.getEpochSecond(1_500_000_000_000L), 1L);
+        assertEquals(ts.getNanos(1_500_000_000_000L), 500_000_000);
+        assertEquals(ts.getEpochSecond(-1L), -1L);
+        assertEquals(ts.getNanos(-1L), 999_999_999);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1747,7 +1747,7 @@ public abstract class IcebergAbstractMetadata
             }
             else if (tableVersion.getVersionExpressionType() instanceof TimestampType) {
                 long timestampValue = (long) tableVersion.getTableVersion();
-                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
+                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).toEpochMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
             else if (tableVersion.getVersionExpressionType() instanceof BigintType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -89,8 +89,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -454,8 +452,7 @@ public class IcebergPageSink
             return type.getSlice(block, position).toStringUtf8();
         }
         if (type instanceof TimestampType) {
-            long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+            return ((TimestampType) type).toEpochMicros(type.getLong(block, position));
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -469,14 +466,13 @@ public class IcebergPageSink
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
-            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
-                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            Instant instant = Instant.ofEpochSecond(timestampType.getEpochSecond(timestampValue),
+                    timestampType.getNanos(timestampValue));
             LocalDateTime localDateTime = instant
                     .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
                     .toLocalDateTime();
 
-            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
-                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+            return timestampType.fromEpochComponents(localDateTime.toEpochSecond(ZoneOffset.UTC), localDateTime.getNano());
         }
         return value;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -299,7 +299,7 @@ public class PartitionTable
         }
         if (type instanceof Types.TimestampType) {
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
-            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).isMillisPrecision()) {
                 return MICROSECONDS.toMillis((long) value);
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -573,7 +573,7 @@ public class IOPlanPrinter
             }
             if (type instanceof TimestampType) {
                 TimestampType timestampType = (TimestampType) type;
-                long timestampValue = timestampType.getPrecision().toMillis((Long) value);
+                long timestampValue = timestampType.toEpochMillis((Long) value);
                 return printTimestampWithoutTimeZone(timestampValue);
             }
             if (type instanceof TimestampWithTimeZoneType) {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Generalize TIMESTAMP handling to support multiple precisions while preserving backward compatibility and update Iceberg integration and planning utilities to use the new APIs.

New Features:
- Introduce precision-aware TIMESTAMP type instances up to precision 12 with a factory and helpers for epoch conversions.

Enhancements:
- Refactor TimestampType to use an integer precision model, interned instances, and precision-scale utilities for converting to and from epoch components.
- Expose helper methods on TimestampType for epoch second, nanosecond, and millisecond/microsecond conversions and legacy TimeUnit interop.
- Update Iceberg partitioning, page sink, and snapshot version resolution to use the new TimestampType helpers instead of directly manipulating TimeUnit-based precisions.
- Adjust IO plan printing to rely on TimestampType epoch conversion helpers for timestamp rendering.

Tests:
- Add unit tests for TimestampType covering interning, precision handling, short vs long representations, epoch component calculations across precisions, and negative timestamp behavior.