### PR TITLE
feat: Introduce LongTimestamp value type

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
@@ -40,6 +40,7 @@ public final class BlockEncodingManager
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlock.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
+import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
+import static com.facebook.presto.common.array.Arrays.ensureCapacity;
+import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+
+// getLong(position, 0) -> epochMicros; getInt(position) -> picosOfMicro.
+public class Fixed12ArrayBlock
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlock.class).instanceSize();
+    public static final int FIXED12_BYTES = Integer.BYTES * 3;
+    public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
+
+    static final int INTS_PER_POSITION = 3;
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long retainedSizeInBytes;
+
+    public Fixed12ArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values);
+    }
+
+    Fixed12ArrayBlock(int positionOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - (positionOffset * INTS_PER_POSITION) < positionCount * INTS_PER_POSITION) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position)
+    {
+        checkReadablePosition(position);
+        return getEpochMicros(position + positionOffset);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position + positionOffset);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return getPicosOfMicro(position + positionOffset);
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && isNullUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        blockBuilder.writeLong(getEpochMicros(internalPosition))
+                .writeInt(getPicosOfMicro(internalPosition))
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            int internalPosition = position + positionOffset;
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(internalPosition));
+            output.writeInt(getPicosOfMicro(internalPosition));
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int internalPosition = position + positionOffset;
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                new int[] {
+                        values[internalPosition * INTS_PER_POSITION],
+                        values[internalPosition * INTS_PER_POSITION + 1],
+                        values[internalPosition * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            int internalPosition = position + positionOffset;
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[internalPosition];
+            }
+            newValues[i * INTS_PER_POSITION] = values[internalPosition * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[internalPosition * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[internalPosition * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+        return new Fixed12ArrayBlock(positionOffset + this.positionOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlock(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getPicosOfMicro(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return positionOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public Block appendNull()
+    {
+        boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
+        int[] newValues = ensureCapacity(values, (positionOffset + positionCount + 1) * INTS_PER_POSITION, SMALL, PRESERVE);
+        return new Fixed12ArrayBlock(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Fixed12ArrayBlock other = (Fixed12ArrayBlock) obj;
+        return this.positionOffset == other.positionOffset &&
+                this.positionCount == other.positionCount &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset, positionCount, Arrays.hashCode(valueIsNull), Arrays.hashCode(values));
+    }
+
+    // & 0xFFFFFFFFL prevents sign extension of the low 32-bit word.
+    private long getEpochMicros(int internalPosition)
+    {
+        int base = internalPosition * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private int getPicosOfMicro(int internalPosition)
+    {
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockBuilder.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.Fixed12ArrayBlock.FIXED12_BYTES;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+// Write protocol — each non-null entry must follow this exact sequence:
+//   writeLong(epochMicros)   — stores the 8-byte epoch-microseconds component
+//   writeInt(picosOfMicro)   — stores the 4-byte sub-microsecond remainder [0, 999_999]
+//   closeEntry()             — commits the position; no heap allocation in the hot path
+//
+// Null entries are written with appendNull() alone — no prior writeLong/writeInt call.
+// Violating either ordering rule throws IllegalStateException immediately.
+public class Fixed12ArrayBlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12ArrayBlockBuilder.class).instanceSize();
+    private static final Block NULL_VALUE_BLOCK = new Fixed12ArrayBlock(0, 1, new boolean[] {true}, new int[3]);
+
+    private static final int INTS_PER_POSITION = Fixed12ArrayBlock.INTS_PER_POSITION;
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+
+    private boolean[] valueIsNull = new boolean[0];
+    private int[] values = new int[0];
+
+    private long retainedSizeInBytes;
+
+    private int entryFieldCount;
+
+    public Fixed12ArrayBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        updateDataSize();
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("writeLong must be the first write for each entry");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        int base = positionCount * INTS_PER_POSITION;
+        values[base] = (int) (value >>> 32);
+        values[base + 1] = (int) value;
+        entryFieldCount = 1;
+        hasNonNullValue = true;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        if (entryFieldCount != 1) {
+            throw new IllegalStateException("writeInt must follow writeLong for each entry");
+        }
+        values[positionCount * INTS_PER_POSITION + 2] = value;
+        entryFieldCount = 2;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (entryFieldCount != 2) {
+            throw new IllegalStateException(
+                    "Each entry requires writeLong(epochMicros) then writeInt(picosOfMicro) before closeEntry()");
+        }
+        positionCount++;
+        entryFieldCount = 0;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (entryFieldCount != 0) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        valueIsNull[positionCount] = true;
+        hasNullValue = true;
+        positionCount++;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
+        return new Fixed12ArrayBlock(0, positionCount, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Fixed12ArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * INTS_PER_POSITION);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position)
+    {
+        checkReadablePosition(position);
+        return getEpochMicros(position);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be 0");
+        }
+        return getEpochMicros(position);
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return values[position * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        blockBuilder.writeLong(getEpochMicros(position))
+                .writeInt(values[position * INTS_PER_POSITION + 2])
+                .closeEntry();
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            output.writeLong(getEpochMicros(position));
+            output.writeInt(values[position * INTS_PER_POSITION + 2]);
+        }
+    }
+
+    @Override
+    public BlockBuilder readPositionFrom(SliceInput input)
+    {
+        boolean isNull = input.readByte() == 0;
+        if (isNull) {
+            appendNull();
+        }
+        else {
+            writeLong(input.readLong());
+            writeInt(input.readInt());
+            closeEntry();
+        }
+        return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new Fixed12ArrayBlock(
+                0,
+                1,
+                valueIsNull[position] ? new boolean[] {true} : null,
+                new int[] {
+                        values[position * INTS_PER_POSITION],
+                        values[position * INTS_PER_POSITION + 1],
+                        values[position * INTS_PER_POSITION + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INTS_PER_POSITION];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (hasNullValue) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            newValues[i * INTS_PER_POSITION] = values[position * INTS_PER_POSITION];
+            newValues[i * INTS_PER_POSITION + 1] = values[position * INTS_PER_POSITION + 1];
+            newValues[i * INTS_PER_POSITION + 2] = values[position * INTS_PER_POSITION + 2];
+        }
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        return new Fixed12ArrayBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        int[] newValues = compactArray(values, positionOffset * INTS_PER_POSITION, length * INTS_PER_POSITION);
+        return new Fixed12ArrayBlock(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12ArrayBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12ArrayBlockBuilder(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getEpochMicros(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition * INTS_PER_POSITION + 2];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    private long getEpochMicros(int position)
+    {
+        int base = position * INTS_PER_POSITION;
+        return ((long) values[base] << 32) | (values[base + 1] & 0xFFFFFFFFL);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12ArrayBlockEncoding.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
+import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
+
+public class Fixed12ArrayBlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "FIXED12_ARRAY";
+    private static final int INTS_PER_POSITION = Fixed12ArrayBlock.INTS_PER_POSITION;
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        boolean mayHaveNull = block.mayHaveNull();
+        for (int position = 0; position < positionCount; position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        int[] values = new int[positionCount * INTS_PER_POSITION];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull == null || !valueIsNull[position]) {
+                long epochMicros = sliceInput.readLong();
+                int picosOfMicro = sliceInput.readInt();
+                int base = position * INTS_PER_POSITION;
+                values[base] = (int) (epochMicros >>> 32);
+                values[base + 1] = (int) epochMicros;
+                values[base + 2] = picosOfMicro;
+            }
+        }
+
+        return new Fixed12ArrayBlock(0, positionCount, valueIsNull, values);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -33,7 +33,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final int getFixedSize()
+    public int getFixedSize()
     {
         return Long.BYTES;
     }
@@ -69,13 +69,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final void writeLong(BlockBuilder blockBuilder, long value)
+    public void writeLong(BlockBuilder blockBuilder, long value)
     {
         blockBuilder.writeLong(value).closeEntry();
     }
 
     @Override
-    public final void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
     {
         if (block.isNull(position)) {
             blockBuilder.appendNull();
@@ -108,7 +108,7 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
@@ -123,13 +123,13 @@ public abstract class AbstractLongType
     }
 
     @Override
-    public final BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, Long.BYTES);
     }
 
     @Override
-    public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
         return new LongArrayBlockBuilder(null, positionCount);
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Objects;
+
+public final class LongTimestamp
+{
+    public static final int MAX_PICOS_OF_MICRO = 999_999;
+
+    private final long epochMicros;
+    private final int picosOfMicro;
+
+    public LongTimestamp(long epochMicros, int picosOfMicro)
+    {
+        if (picosOfMicro < 0 || picosOfMicro > MAX_PICOS_OF_MICRO) {
+            throw new IllegalArgumentException(
+                    "picosOfMicro must be in [0, " + MAX_PICOS_OF_MICRO + "]: " + picosOfMicro);
+        }
+        this.epochMicros = epochMicros;
+        this.picosOfMicro = picosOfMicro;
+    }
+
+    public long getEpochMicros()
+    {
+        return epochMicros;
+    }
+
+    public int getPicosOfMicro()
+    {
+        return picosOfMicro;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongTimestamp that = (LongTimestamp) o;
+        return epochMicros == that.epochMicros && picosOfMicro == that.picosOfMicro;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(epochMicros, picosOfMicro);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LongTimestamp{epochMicros=" + epochMicros + ", picosOfMicro=" + picosOfMicro + "}";
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -14,6 +14,11 @@
 package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
+import com.facebook.presto.common.block.Fixed12ArrayBlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import java.util.concurrent.TimeUnit;
@@ -29,10 +34,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 // number of units elapsed since 1970-01-01T00:00:00 UTC — e.g. p=3 stores epoch-milliseconds and
 // p=6 stores epoch-microseconds.
 //
-// Long precisions (p=7–12) will use a two-field LongTimestamp representation (epochMicros + picosOfMicro)
-// once that type is introduced in a follow-up change (see github.com/prestodb/presto/issues/27934).
-// Instances for p=7–12 are pre-allocated here but their arithmetic helpers throw
-// UnsupportedOperationException until the LongTimestamp path is wired in.
+// Long precisions (p=7–12) use a two-field LongTimestamp representation (epochMicros + picosOfMicro)
+// stored in a Fixed12ArrayBlock. The block encoding infrastructure is in place as of the Phase 1
+// change (github.com/prestodb/presto/issues/27934). SQL grammar, operator registration, and
+// connector I/O are wired in later phases.
 public final class TimestampType
         extends AbstractLongType
 {
@@ -72,6 +77,12 @@ public final class TimestampType
 
     private final int precision;
 
+    private TimestampType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
     // Returns the interned instance for p=0..MAX_PRECISION. Only p=3 and p=6 are registered in
     // the type manager; all other precisions are arithmetic-only until a follow-up change wires
     // full type-system support (see github.com/prestodb/presto/issues/27934).
@@ -82,12 +93,6 @@ public final class TimestampType
                     "TIMESTAMP precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
         }
         return INSTANCES[precision];
-    }
-
-    private TimestampType(int precision)
-    {
-        super(buildTypeSignature(precision));
-        this.precision = precision;
     }
 
     private static TypeSignature buildTypeSignature(int precision)
@@ -153,15 +158,132 @@ public final class TimestampType
         return System.identityHashCode(this);
     }
 
+    @Override
+    public int getFixedSize()
+    {
+        return isShort() ? Long.BYTES : Fixed12ArrayBlock.FIXED12_BYTES;
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        if (!isShort()) {
+            return new Fixed12ArrayBlockBuilder(null, positionCount);
+        }
+        return super.createFixedSizeBlockBuilder(positionCount);
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "writeLong is not supported for TIMESTAMP(" + precision + "); use writeLongTimestamp");
+        }
+        super.writeLong(blockBuilder, value);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else if (isShort()) {
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
+        }
+        else {
+            blockBuilder.writeLong(block.getLong(position, 0))
+                    .writeInt(block.getInt(position))
+                    .closeEntry();
+        }
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        if (!isShort()) {
+            int maxBlockSizeInBytes = blockBuilderStatus == null
+                    ? PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES
+                    : blockBuilderStatus.getMaxPageSizeInBytes();
+            return new Fixed12ArrayBlockBuilder(
+                    blockBuilderStatus,
+                    Math.min(expectedEntries, maxBlockSizeInBytes / Fixed12ArrayBlock.FIXED12_BYTES));
+        }
+        return super.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+    }
+
+    public void writeLongTimestamp(BlockBuilder blockBuilder, LongTimestamp value)
+    {
+        if (isShort()) {
+            throw new UnsupportedOperationException(
+                    "writeLongTimestamp is not supported for short TIMESTAMP(" + precision + "); use writeLong");
+        }
+        blockBuilder.writeLong(value.getEpochMicros())
+                .writeInt(value.getPicosOfMicro())
+                .closeEntry();
+    }
+
+    // Not for use in scan/projection hot paths — allocates a LongTimestamp per call.
+    public LongTimestamp getLongTimestamp(Block block, int position)
+    {
+        if (isShort()) {
+            throw new UnsupportedOperationException(
+                    "getLongTimestamp is not supported for short TIMESTAMP(" + precision + "); use getLong");
+        }
+        return new LongTimestamp(block.getLong(position, 0), block.getInt(position));
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            int epochCompare = Long.compare(leftBlock.getLong(leftPosition), rightBlock.getLong(rightPosition));
+            if (epochCompare != 0) {
+                return epochCompare;
+            }
+            return Integer.compare(leftBlock.getInt(leftPosition), rightBlock.getInt(rightPosition));
+        }
+        return super.compareTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (!isShort()) {
+            return leftBlock.getLong(leftPosition) == rightBlock.getLong(rightPosition)
+                    && leftBlock.getInt(leftPosition) == rightBlock.getInt(rightPosition);
+        }
+        return super.equalTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        if (!isShort()) {
+            long epochHash = AbstractLongType.hash(block.getLong(position));
+            return 31 * epochHash + AbstractLongType.hash(block.getInt(position));
+        }
+        return super.hash(block, position);
+    }
+
     // Floor division gives the correct epoch-second for negative (pre-1970) timestamps.
     public long getEpochSecond(long timestamp)
     {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getEpochSecond is not supported for TIMESTAMP(" + precision + "); use LongTimestamp.getEpochMicros()");
+        }
         return floorDiv(timestamp, PRECISION_SCALE[precision]);
     }
 
     // Floor modulo handles negative (pre-1970) timestamps correctly; Java % does not.
     public int getNanos(long timestamp)
     {
+        if (!isShort()) {
+            throw new UnsupportedOperationException(
+                    "getNanos is not supported for TIMESTAMP(" + precision + "); use LongTimestamp.getPicosOfMicro()");
+        }
         long fractional = floorMod(timestamp, PRECISION_SCALE[precision]);
         long scale = PRECISION_SCALE[precision];
         // For p <= 9, scale <= 1e9: multiply up to nanoseconds.

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12ArrayBlock.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.LongTimestamp;
+import com.facebook.presto.common.type.TimestampType;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.createTimestampType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestFixed12ArrayBlock
+{
+    @Test
+    public void testSinglePositionRoundTrip()
+    {
+        long epochMicros = 1_000_000_000L;
+        int picosOfMicro = 500_000;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 1);
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        long epochMicros = -1_000_000L;
+        int picosOfMicro = 999_999;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testMultiplePositions()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(200L).writeInt(999_999).closeEntry();
+        builder.writeLong(-300L).writeInt(500_000).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getLong(0, 0), 100L);
+        assertEquals(block.getInt(0), 0);
+        assertEquals(block.getLong(1, 0), 200L);
+        assertEquals(block.getInt(1), 999_999);
+        assertEquals(block.getLong(2, 0), -300L);
+        assertEquals(block.getInt(2), 500_000);
+    }
+
+    @Test
+    public void testNullPosition()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 2);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+    }
+
+    @Test
+    public void testSizeInBytes()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 4);
+        for (int i = 0; i < 4; i++) {
+            builder.writeLong((long) i * 1000).writeInt(i).closeEntry();
+        }
+        Block block = builder.build();
+        assertEquals(block.getSizeInBytes(), Fixed12ArrayBlock.SIZE_IN_BYTES_PER_POSITION * 4L);
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForLongPrecision()
+    {
+        TimestampType longType = createTimestampType(7);
+        assertFalse(longType.isShort());
+        BlockBuilder builder = longType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof Fixed12ArrayBlockBuilder,
+                "Expected Fixed12ArrayBlockBuilder for p=7, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testTimestampTypeCreateBlockBuilderForShortPrecision()
+    {
+        TimestampType shortType = createTimestampType(6);
+        assertTrue(shortType.isShort());
+        BlockBuilder builder = shortType.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof LongArrayBlockBuilder,
+                "Expected LongArrayBlockBuilder for p=6, got: " + builder.getClass().getSimpleName());
+    }
+
+    @Test
+    public void testEncodingRoundTrip()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000_000L).writeInt(500_000).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999_999L).writeInt(999_999).closeEntry();
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(256);
+        Fixed12ArrayBlockEncoding encoding = new Fixed12ArrayBlockEncoding();
+        encoding.writeBlock(null, sliceOutput, original);
+
+        SliceInput sliceInput = sliceOutput.slice().getInput();
+        Block decoded = encoding.readBlock(null, sliceInput);
+
+        assertEquals(decoded.getPositionCount(), 3);
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertTrue(decoded.isNull(1));
+        assertFalse(decoded.isNull(2));
+        assertEquals(decoded.getLong(2, 0), -999_999L);
+        assertEquals(decoded.getInt(2), 999_999);
+    }
+
+    @Test
+    public void testExtremeNegativeEpoch()
+    {
+        long epochMicros = Long.MIN_VALUE;
+        int picosOfMicro = 0;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0, 0), epochMicros);
+        assertEquals(block.getInt(0), picosOfMicro);
+    }
+
+    @Test
+    public void testGetLongNoOffset()
+    {
+        long epochMicros = 1_234_567_890L;
+        int picosOfMicro = 123_456;
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(picosOfMicro).closeEntry();
+
+        Block block = builder.build();
+        assertEquals(block.getLong(0), epochMicros);
+        assertEquals(block.getLong(0, 0), epochMicros);
+    }
+
+    @Test
+    public void testBuilderGetLongNoOffset()
+    {
+        long epochMicros = -999_000L;
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 1);
+        builder.writeLong(epochMicros).writeInt(0).closeEntry();
+
+        assertEquals(builder.getLong(0), epochMicros);
+        assertEquals(builder.getLong(0, 0), epochMicros);
+    }
+
+    @Test
+    public void testAppendToLongPrecision()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder source = new Fixed12ArrayBlockBuilder(null, 2);
+        source.writeLong(1_000_000L).writeInt(500_000).closeEntry();
+        source.appendNull();
+        Block sourceBlock = source.build();
+
+        BlockBuilder dest = longType.createBlockBuilder(null, 2);
+        longType.appendTo(sourceBlock, 0, dest);
+        longType.appendTo(sourceBlock, 1, dest);
+        Block destBlock = dest.build();
+
+        assertEquals(destBlock.getPositionCount(), 2);
+        assertFalse(destBlock.isNull(0));
+        assertEquals(destBlock.getLong(0, 0), 1_000_000L);
+        assertEquals(destBlock.getInt(0), 500_000);
+        assertTrue(destBlock.isNull(1));
+    }
+
+    @Test
+    public void testWriteLongTimestampRoundTrip()
+    {
+        TimestampType longType = createTimestampType(9);
+        LongTimestamp original = new LongTimestamp(9_876_543_210L, 999_999);
+
+        BlockBuilder builder = longType.createBlockBuilder(null, 1);
+        longType.writeLongTimestamp(builder, original);
+        Block block = builder.build();
+
+        LongTimestamp read = longType.getLongTimestamp(block, 0);
+        assertEquals(read, original);
+    }
+
+    @Test
+    public void testCompareTo()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(200L).writeInt(0).closeEntry();
+        Block block = builder.build();
+
+        // equal values
+        assertEquals(longType.compareTo(block, 0, block, 0), 0);
+        // same epochMicros, different picosOfMicro
+        assertTrue(longType.compareTo(block, 0, block, 1) < 0);
+        assertTrue(longType.compareTo(block, 1, block, 0) > 0);
+        // different epochMicros
+        assertTrue(longType.compareTo(block, 0, block, 2) < 0);
+        assertTrue(longType.compareTo(block, 2, block, 0) > 0);
+    }
+
+    @Test
+    public void testEqualTo()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(100L).writeInt(500_000).closeEntry();
+        builder.writeLong(100L).writeInt(999_999).closeEntry();
+        Block block = builder.build();
+
+        assertTrue(longType.equalTo(block, 0, block, 0), "value must equal itself");
+        assertTrue(longType.equalTo(block, 0, block, 1), "identical values must be equal");
+        assertFalse(longType.equalTo(block, 0, block, 2), "same epochMicros but different picosOfMicro must not be equal");
+    }
+
+    @Test
+    public void testHashEqualsContract()
+    {
+        TimestampType longType = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(42L).writeInt(7).closeEntry();
+        builder.writeLong(42L).writeInt(7).closeEntry();
+        Block block = builder.build();
+
+        assertTrue(longType.equalTo(block, 0, block, 1));
+        assertEquals(longType.hash(block, 0), longType.hash(block, 1),
+                "equal values must have the same hash");
+    }
+
+    @Test
+    public void testHashDifferentiatesByPicosOfMicro()
+    {
+        // Guards against a future bug where hash() ignores the picosOfMicro field.
+        TimestampType nanos = createTimestampType(9);
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 2);
+        builder.writeLong(100L).writeInt(0).closeEntry();
+        builder.writeLong(100L).writeInt(1).closeEntry();
+        Block block = builder.build();
+
+        assertNotEquals(nanos.hash(block, 0), nanos.hash(block, 1),
+                "same epochMicros but different picosOfMicro must produce different hashes");
+    }
+
+    @Test
+    public void testGetRegionWithNonZeroOffset()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 5);
+        for (int i = 0; i < 5; i++) {
+            builder.writeLong((long) (i + 1) * 100).writeInt(i * 10).closeEntry();
+        }
+        Block block = builder.build();
+
+        Block region1 = block.getRegion(1, 4);
+        assertEquals(region1.getPositionCount(), 4);
+        assertEquals(region1.getLong(0, 0), 200L);
+        assertEquals(region1.getInt(0), 10);
+
+        Block region2 = region1.getRegion(1, 2);
+        assertEquals(region2.getPositionCount(), 2);
+        assertEquals(region2.getLong(0, 0), 300L);
+        assertEquals(region2.getInt(0), 20);
+        assertEquals(region2.getLong(1, 0), 400L);
+        assertEquals(region2.getInt(1), 30);
+    }
+
+    @Test
+    public void testCopyRegionWithNonZeroOffset()
+    {
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 5);
+        for (int i = 0; i < 5; i++) {
+            builder.writeLong((long) (i + 1) * 100).writeInt(i * 10).closeEntry();
+        }
+        Block block = builder.build();
+
+        Block region = block.getRegion(2, 3);
+        Block copy = region.copyRegion(0, 2);
+
+        assertEquals(copy.getPositionCount(), 2);
+        assertEquals(copy.getLong(0, 0), 300L);
+        assertEquals(copy.getInt(0), 20);
+        assertEquals(copy.getLong(1, 0), 400L);
+        assertEquals(copy.getInt(1), 30);
+        assertEquals(copy.getLong(0, 0), region.getLong(0, 0));
+    }
+
+    @Test
+    public void testEncodingRoundTripViaSerde()
+    {
+        BlockEncodingSerde serde = new TestingBlockEncodingSerde();
+
+        Fixed12ArrayBlockBuilder builder = new Fixed12ArrayBlockBuilder(null, 3);
+        builder.writeLong(1_000_000_000L).writeInt(500_000).closeEntry();
+        builder.appendNull();
+        builder.writeLong(-999_999L).writeInt(999_999).closeEntry();
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(256);
+        serde.writeBlock(sliceOutput, original);
+        Block decoded = serde.readBlock(sliceOutput.slice().getInput());
+
+        assertEquals(decoded.getPositionCount(), 3);
+        assertFalse(decoded.isNull(0));
+        assertEquals(decoded.getLong(0, 0), 1_000_000_000L);
+        assertEquals(decoded.getInt(0), 500_000);
+        assertTrue(decoded.isNull(1));
+        assertFalse(decoded.isNull(2));
+        assertEquals(decoded.getLong(2, 0), -999_999L);
+        assertEquals(decoded.getInt(2), 999_999);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestingBlockEncodingSerde.java
@@ -47,6 +47,7 @@ public final class TestingBlockEncodingSerde
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+public class TestLongTimestamp
+{
+    @Test
+    public void testConstructorStoresFields()
+    {
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 500_000);
+        assertEquals(ts.getEpochMicros(), 1_000_000L);
+        assertEquals(ts.getPicosOfMicro(), 500_000);
+    }
+
+    @Test
+    public void testPicosOfMicroLowerBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test
+    public void testPicosOfMicroUpperBound()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 999_999);
+        assertEquals(ts.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testPicosOfMicroNegativeThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> new LongTimestamp(0L, -1));
+    }
+
+    @Test
+    public void testPicosOfMicroTooLargeThrows()
+    {
+        expectThrows(IllegalArgumentException.class, () -> new LongTimestamp(0L, 1_000_000));
+    }
+
+    @Test
+    public void testNegativeEpochMicros()
+    {
+        // Pre-1970 timestamp: negative epochMicros is valid
+        LongTimestamp ts = new LongTimestamp(-1_000_000L, 0);
+        assertEquals(ts.getEpochMicros(), -1_000_000L);
+    }
+
+    @Test
+    public void testImmutable()
+    {
+        // LongTimestamp has no setters — verified by reading fields without modification
+        LongTimestamp ts = new LongTimestamp(42L, 100);
+        assertEquals(ts.getEpochMicros(), 42L);
+        assertEquals(ts.getPicosOfMicro(), 100);
+        // No setter methods exist; this is verified at compile time by the absence of set* methods
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.type;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.Fixed12ArrayBlock;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import org.testng.annotations.Test;
 
@@ -27,6 +28,7 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -40,6 +42,15 @@ public class TestTimestampType
             assertSame(createTimestampType(p), createTimestampType(p),
                     "createTimestampType(" + p + ") must return the same reference on repeated calls");
         }
+    }
+
+    @Test
+    public void testConstantsAreNonNull()
+    {
+        // Guards against static initialization order regressions: the static block filling INSTANCES
+        // must execute before TIMESTAMP and TIMESTAMP_MICROSECONDS are assigned.
+        assertNotNull(TIMESTAMP, "TIMESTAMP constant must not be null");
+        assertNotNull(TIMESTAMP_MICROSECONDS, "TIMESTAMP_MICROSECONDS constant must not be null");
     }
 
     @Test
@@ -166,7 +177,7 @@ public class TestTimestampType
         assertEquals(createTimestampType(0).toEpochMicros(-1L), -1_000_000L);
         assertEquals(createTimestampType(3).toEpochMicros(1_500L), 1_500_000L);
         assertEquals(createTimestampType(3).toEpochMicros(0L), 0L);
-        // Pre-epoch: IcebergPageSink uses toEpochMicros for p=3 (millis → micros).
+        // Pre-epoch: IcebergPageSink uses toEpochMicros for p=3 (millis -> micros).
         assertEquals(createTimestampType(3).toEpochMicros(-1L), -1_000L);
         assertEquals(createTimestampType(3).toEpochMicros(-1_000L), -1_000_000L);
         assertEquals(createTimestampType(3).toEpochMicros(-1_001L), -1_001_000L);
@@ -267,5 +278,165 @@ public class TestTimestampType
             assertEquals(micros.fromEpochComponents(micros.getEpochSecond(v), (int) micros.getNanos(v)), v,
                     "round-trip failed for p=6, v=" + v);
         }
+    }
+
+    @Test
+    public void testGetEpochSecondThrowsForLongPrecision()
+    {
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            TimestampType ts = createTimestampType(p);
+            expectThrows(UnsupportedOperationException.class, () -> ts.getEpochSecond(0L));
+            expectThrows(UnsupportedOperationException.class, () -> ts.getNanos(0L));
+        }
+    }
+
+    @Test
+    public void testGetFixedSize()
+    {
+        for (int p = 0; p <= TimestampType.MAX_SHORT_PRECISION; p++) {
+            assertEquals(createTimestampType(p).getFixedSize(), Long.BYTES,
+                    "short precision p=" + p + " must report Long.BYTES");
+        }
+        for (int p = TimestampType.MAX_SHORT_PRECISION + 1; p <= TimestampType.MAX_PRECISION; p++) {
+            assertEquals(createTimestampType(p).getFixedSize(), Fixed12ArrayBlock.FIXED12_BYTES,
+                    "long precision p=" + p + " must report FIXED12_BYTES");
+        }
+    }
+
+    @Test
+    public void testWriteLongThrowsForLongPrecision()
+    {
+        TimestampType longType = createTimestampType(9);
+        BlockBuilder builder = longType.createBlockBuilder(null, 1);
+        expectThrows(UnsupportedOperationException.class, () -> longType.writeLong(builder, 0L));
+    }
+
+    @Test
+    public void testWriteLongWorksForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_500L);
+        Block block = builder.build();
+        assertEquals(block.getLong(0), 1_500L);
+    }
+
+    @Test
+    public void testWriteLongTimestampAndGetLongTimestamp()
+    {
+        TimestampType nanos = createTimestampType(9);
+        LongTimestamp ts = new LongTimestamp(1_000_000L, 999_999);
+
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, ts);
+        Block block = builder.build();
+
+        LongTimestamp read = nanos.getLongTimestamp(block, 0);
+        assertEquals(read.getEpochMicros(), 1_000_000L);
+        assertEquals(read.getPicosOfMicro(), 999_999);
+    }
+
+    @Test
+    public void testWriteLongTimestampThrowsForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        expectThrows(UnsupportedOperationException.class,
+                () -> millis.writeLongTimestamp(builder, new LongTimestamp(0L, 0)));
+    }
+
+    @Test
+    public void testGetLongTimestampThrowsForShortPrecision()
+    {
+        TimestampType millis = createTimestampType(3);
+        BlockBuilder builder = millis.createBlockBuilder(null, 1);
+        millis.writeLong(builder, 1_000L);
+        Block block = builder.build();
+        expectThrows(UnsupportedOperationException.class, () -> millis.getLongTimestamp(block, 0));
+    }
+
+    @Test
+    public void testAppendToLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder source = nanos.createBlockBuilder(null, 2);
+        nanos.writeLongTimestamp(source, new LongTimestamp(5_000_000L, 123_456));
+        source.appendNull();
+        Block sourceBlock = source.build();
+
+        BlockBuilder dest = nanos.createBlockBuilder(null, 2);
+        nanos.appendTo(sourceBlock, 0, dest);
+        nanos.appendTo(sourceBlock, 1, dest);
+        Block destBlock = dest.build();
+
+        assertFalse(destBlock.isNull(0));
+        assertEquals(destBlock.getLong(0, 0), 5_000_000L);
+        assertEquals(destBlock.getInt(0), 123_456);
+        assertTrue(destBlock.isNull(1));
+    }
+
+    @Test
+    public void testCompareToLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 3);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 0));
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 500_000));
+        nanos.writeLongTimestamp(builder, new LongTimestamp(200L, 0));
+        Block block = builder.build();
+
+        assertEquals(nanos.compareTo(block, 0, block, 0), 0);
+        assertTrue(nanos.compareTo(block, 0, block, 1) < 0);
+        assertTrue(nanos.compareTo(block, 1, block, 0) > 0);
+        assertTrue(nanos.compareTo(block, 0, block, 2) < 0);
+        assertTrue(nanos.compareTo(block, 2, block, 0) > 0);
+    }
+
+    @Test
+    public void testEqualToLongPrecision()
+    {
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 2);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 500_000));
+        nanos.writeLongTimestamp(builder, new LongTimestamp(100L, 500_000));
+        Block block = builder.build();
+
+        assertTrue(nanos.equalTo(block, 0, block, 1));
+        assertTrue(nanos.equalTo(block, 0, block, 0));
+    }
+
+    @Test
+    public void testHashLongPrecision()
+    {
+        // hash must not throw for long-precision blocks
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder builder = nanos.createBlockBuilder(null, 1);
+        nanos.writeLongTimestamp(builder, new LongTimestamp(42L, 7));
+        Block block = builder.build();
+
+        long h1 = nanos.hash(block, 0);
+        long h2 = nanos.hash(block, 0);
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    public void testAppendToRleNullBlock()
+    {
+        // Fixed12ArrayBlockBuilder.build() returns a RunLengthEncodedBlock when all entries are null.
+        // appendTo must handle the RLE-wrapped null without attempting getLong/getInt.
+        TimestampType nanos = createTimestampType(9);
+        BlockBuilder source = nanos.createBlockBuilder(null, 2);
+        source.appendNull();
+        source.appendNull();
+        Block rleBlock = source.build();
+
+        BlockBuilder dest = nanos.createBlockBuilder(null, 2);
+        nanos.appendTo(rleBlock, 0, dest);
+        nanos.appendTo(rleBlock, 1, dest);
+        Block result = dest.build();
+
+        assertEquals(result.getPositionCount(), 2);
+        assertTrue(result.isNull(0));
+        assertTrue(result.isNull(1));
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a LongTimestamp value type and wire long-precision TIMESTAMPs to use a new Fixed12ArrayBlock storage layout while keeping short-precision TIMESTAMP behavior unchanged.

New Features:
- Add LongTimestamp value type representing high-precision timestamps with microsecond and picosecond components.
- Introduce Fixed12ArrayBlock and corresponding block builder/encoding for compact 12-byte fixed-size storage, and use it for long-precision TIMESTAMP types.

Enhancements:
- Update TimestampType and AbstractLongType to support distinct storage strategies for short and long-precision timestamps, including comparison, hashing, and block builder creation logic.

Tests:
- Add unit tests for LongTimestamp, Fixed12ArrayBlock and its encoding, and extended TimestampType tests to cover long-precision behavior and null-handling edge cases.