### PR TITLE
feat(timestamp): Enhance TimestampWithTimeZoneType with precision handling

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -16,17 +16,60 @@ package com.facebook.presto.common.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
+import java.util.Objects;
+
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
 
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
-    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+    public static final int MAX_PRECISION = 12;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private TimestampWithTimeZoneType()
+    private static final TimestampWithTimeZoneType[] INSTANCES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampWithTimeZoneType(p);
+        }
+    }
+
+    // Preserves "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = INSTANCES[DEFAULT_PRECISION];
+
+    private final int precision;
+
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %s]: %s", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampWithTimeZoneType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        }
+        // Other precisions use a numeric parameter; the type registry does not yet recognize the
+        // "timestamp with time zone(p)" string form, so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+    }
+
+    public int getPrecision()
+    {
+        return precision;
     }
 
     /**
@@ -78,12 +121,13 @@ public final class TimestampWithTimeZoneType
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == TIMESTAMP_WITH_TIME_ZONE;
+        // One interned instance per precision level, so reference equality is sufficient.
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return getClass().hashCode();
+        return Objects.hash(getClass(), precision);
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class TestTimestampWithTimeZoneType
+{
+    @Test
+    public void testInterning()
+    {
+        for (int p = 0; p <= 12; p++) {
+            assertSame(createTimestampWithTimeZoneType(p), createTimestampWithTimeZoneType(p),
+                    "Expected same instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testPreAllocation()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampWithTimeZoneType instance = createTimestampWithTimeZoneType(p);
+            assertEquals(instance.getPrecision(), p);
+        }
+    }
+
+    @Test
+    public void testBackwardCompatConstant()
+    {
+        assertSame(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getPrecision(), 3);
+    }
+
+    @Test
+    public void testBackwardCompatTypeSignature()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getBase(), "timestamp with time zone");
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testReferenceEquality()
+    {
+        TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(6);
+        TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(6);
+        assertSame(a, b);
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsWithConstant()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testInvalidPrecisionNegative()
+    {
+        try {
+            createTimestampWithTimeZoneType(-1);
+            fail("Expected IllegalArgumentException for precision -1");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidPrecisionTooLarge()
+    {
+        try {
+            createTimestampWithTimeZoneType(13);
+            fail("Expected IllegalArgumentException for precision 13");
+        }
+        catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    // All 13 instances are distinct objects
+    @Test
+    public void testDistinctInstances()
+    {
+        for (int p = 0; p <= 12; p++) {
+            for (int q = p + 1; q <= 12; q++) {
+                TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
+                TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
+                // Different precisions → different instances
+                assert a != b : "Expected distinct instances for p=" + p + " and q=" + q;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add precision-aware variants of TimestampWithTimeZoneType while preserving backward compatibility with the existing unparameterized type.

New Features:
- Introduce precision-specific TimestampWithTimeZoneType instances with a factory method supporting a defined precision range.

Enhancements:
- Pre-allocate and intern TimestampWithTimeZoneType instances per precision level to ensure reference equality and efficient reuse.
- Expose precision metadata on TimestampWithTimeZoneType and refine equality and hash code semantics to account for precision.

Tests:
- Add unit tests covering interning behavior, precision handling, backward-compatible constants and type signatures, equality semantics, and invalid precision validation.