### PR TITLE
feat: Parameterize TimestampWithTimeZoneType by precision 3

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -18,15 +18,56 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.lang.String.format;
 
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
-    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+    public static final int MAX_PRECISION = 12;
+    public static final int DEFAULT_PRECISION = 3;
 
-    private TimestampWithTimeZoneType()
+    private static final TimestampWithTimeZoneType[] INSTANCES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
+
+    static {
+        for (int p = 0; p <= MAX_PRECISION; p++) {
+            INSTANCES[p] = new TimestampWithTimeZoneType(p);
+        }
+    }
+
+    public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = INSTANCES[DEFAULT_PRECISION];
+
+    private final int precision;
+
+    // Only p=3 is registered in the type manager; other precisions tracked in #27934.
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format(
+                    "TIMESTAMP WITH TIME ZONE precision must be in range [0, %d]: %d", MAX_PRECISION, precision));
+        }
+        return INSTANCES[precision];
+    }
+
+    private TimestampWithTimeZoneType(int precision)
+    {
+        super(buildTypeSignature(precision));
+        this.precision = precision;
+    }
+
+    private static TypeSignature buildTypeSignature(int precision)
+    {
+        if (precision == DEFAULT_PRECISION) {
+            // Preserve "timestamp with time zone" (no parameter) so existing serialized metadata continues to parse.
+            return parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        }
+        // The type registry does not yet recognize the "timestamp with time zone(p)" string form,
+        // so these instances are created directly rather than parsed.
+        return new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE, TypeSignatureParameter.of((long) precision));
+    }
+
+    public int getPrecision()
+    {
+        return precision;
     }
 
     /**
@@ -42,16 +83,23 @@ public final class TimestampWithTimeZoneType
         return false;
     }
 
+    // SqlTimestampWithTimeZone has no sub-millisecond representation yet, so silently accepting other
+    // precisions here would truncate values without any indication.
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
         }
+        if (precision != DEFAULT_PRECISION) {
+            throw new UnsupportedOperationException(
+                    "getObjectValue is not supported for TIMESTAMP(" + precision + ") WITH TIME ZONE");
+        }
 
         return new SqlTimestampWithTimeZone(block.getLong(position));
     }
 
+    // TODO(#27934 Phase 2): equalTo/hash/compareTo assume DEFAULT_PRECISION encoding; add precision-aware dispatch.
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
@@ -78,12 +126,12 @@ public final class TimestampWithTimeZoneType
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == TIMESTAMP_WITH_TIME_ZONE;
+        return this == other;
     }
 
     @Override
     public int hashCode()
     {
-        return getClass().hashCode();
+        return System.identityHashCode(this);
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestampWithTimeZoneType.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.expectThrows;
+
+public class TestTimestampWithTimeZoneType
+{
+    @Test
+    public void testInterning()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            assertSame(createTimestampWithTimeZoneType(p), createTimestampWithTimeZoneType(p),
+                    "Expected same instance for precision " + p);
+        }
+    }
+
+    @Test
+    public void testPreAllocation()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            TimestampWithTimeZoneType instance = createTimestampWithTimeZoneType(p);
+            assertEquals(instance.getPrecision(), p);
+        }
+    }
+
+    @Test
+    public void testBackwardCompatConstant()
+    {
+        assertSame(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getPrecision(), 3);
+    }
+
+    @Test
+    public void testBackwardCompatTypeSignature()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getBase(), "timestamp with time zone");
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature().getParameters().size(), 0);
+    }
+
+    @Test
+    public void testReferenceEquality()
+    {
+        TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(6);
+        TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(6);
+        assertSame(a, b);
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsWithConstant()
+    {
+        assertEquals(TIMESTAMP_WITH_TIME_ZONE, createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testInvalidPrecisionNegative()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampWithTimeZoneType(-1));
+    }
+
+    @Test
+    public void testInvalidPrecisionTooLarge()
+    {
+        expectThrows(IllegalArgumentException.class, () -> createTimestampWithTimeZoneType(TimestampWithTimeZoneType.MAX_PRECISION + 1));
+    }
+
+    @Test
+    public void testDistinctInstances()
+    {
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            for (int q = p + 1; q <= TimestampWithTimeZoneType.MAX_PRECISION; q++) {
+                TimestampWithTimeZoneType a = createTimestampWithTimeZoneType(p);
+                TimestampWithTimeZoneType b = createTimestampWithTimeZoneType(q);
+                assertNotSame(a, b, "Expected distinct instances for p=" + p + " and q=" + q);
+            }
+        }
+    }
+
+    @Test
+    public void testGetObjectValueUnsupportedForNonDefaultPrecision()
+    {
+        BlockBuilder builder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(null, 1);
+        TIMESTAMP_WITH_TIME_ZONE.writeLong(builder, 0L);
+        Block block = builder.build();
+
+        for (int p = 0; p <= TimestampWithTimeZoneType.MAX_PRECISION; p++) {
+            if (p == TimestampWithTimeZoneType.DEFAULT_PRECISION) {
+                continue;
+            }
+            TimestampWithTimeZoneType type = createTimestampWithTimeZoneType(p);
+            expectThrows(UnsupportedOperationException.class, () -> type.getObjectValue(null, block, 0));
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Parameterize the TimestampWithTimeZoneType by precision while preserving backward-compatible behavior for the default precision.

New Features:
- Introduce precision-parameterized TimestampWithTimeZoneType instances for all supported precisions.
- Expose a factory method to obtain timestamp-with-time-zone types for a given precision.
- Add a getter for timestamp-with-time-zone precision.

Enhancements:
- Maintain backward-compatible type signature and constant for the default precision to keep existing metadata valid.
- Change equality and hash behavior to rely on instance identity for distinct precision-specific types.
- Guard getObjectValue to fail for non-default precisions until sub-millisecond support is implemented.

Tests:
- Add unit tests covering precision interning, preallocation, backward-compatibility, invalid precision handling, and behavior of getObjectValue for non-default precisions.